### PR TITLE
Update package scripts to support working directory token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## 1.0.0 (IN PROGRESS)
 * New platform created for building and testing core modules
 * Move cross-module tests from `ui-testing` into `platform-core`, UITEST-22
+* Update package scripts to pass working directory token with --run, UITEST-36

--- a/README.md
+++ b/README.md
@@ -32,21 +32,32 @@ or
 
 
 ## Tests
-Tests are run using FOLIO's `ui-testing` framework.  Please refer to [ui-testing](https://github.com/folio-org/ui-testing) for more information on available options.
+Tests are run using FOLIO's `ui-testing` framework.  Please refer to [ui-testing](https://github.com/folio-org/ui-testing) for more information on available options. All examples below require the platform to be built and running at the URL provided.
 
-### Run all tests
-Given a platform is built and running on localhost, the following command will run all of the platform's tests.
-```
-$ yarn test
-```
-
-Optionally provide the URL to a running instance. 
+### Run all platform and app tests
 ```
 $ yarn test --url http://localhost:3000
 ```
 
-### Run a single test
-This also requires a built and running platform.
+### Run platform (cross-module) tests only
 ```
-$ yarn test-module --run :110-auth-success
+$ yarn test-platform --url http://localhost:3000
+```
+
+### Run app module tests only
+```
+$ yarn test-apps --url http://localhost:3000
+```
+
+### Run selected tests
+The `test-module` package script, combined with ui-testing's `--run` option, can be used for running specific tests for the platform and/or apps.  Use `WD` when referencing platform tests, otherwise use the module app module name.
+
+Example platform test:
+```
+$ yarn test-module --run WD:loan_renewal --url http://localhost:3000
+```
+
+Example users test:
+```
+$ yarn test-module --run users:new_user --url http://localhost:3000
 ```

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "stripescore dev stripes.config.js",
     "postinstall": "node ./build-module-descriptors.js",
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripescore dev $f",
-    "test": "mocha ./node_modules/@folio/ui-testing/test-module.js --workingDirectory $PWD --run x",
+    "test": "mocha ./node_modules/@folio/ui-testing/test-module.js --workingDirectory $PWD --run WD/checkin/checkout/users/inventory/requests/circulation/organization",
+    "test-platform": "mocha ./node_modules/@folio/ui-testing/test-module.js --workingDirectory $PWD --run WD",
+    "test-apps": "mocha ./node_modules/@folio/ui-testing/test-module.js --run checkin/checkout/users/inventory/requests/circulation/organization",
     "test-module": "mocha ./node_modules/@folio/ui-testing/test-module.js --workingDirectory $PWD",
     "lint": "eslint test/ui-testing"
   },


### PR DESCRIPTION
This allows platform and app tests to be run together in the same call to ui-testing's test-module.  Examples in the README have been updated to reflect this.

See UITEST-36 for details.

