### PR TITLE
UITEST-35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 * New platform created for building and testing core modules
 * Move cross-module tests from `ui-testing` into `platform-core`, UITEST-22
 * Update package scripts to pass working directory token with --run, UITEST-36
+* Disable tests not currently in invoked by ui-testing, UITEST-35

--- a/test/ui-testing/test.js
+++ b/test/ui-testing/test.js
@@ -1,31 +1,31 @@
-const startPage = require('./100-startpage');
-const authSuccess = require('./110-auth-success');
+// const startPage = require('./100-startpage');
+// const authSuccess = require('./110-auth-success');
 const authFail = require('./120-auth-fail');
 // const calendarTest = require('./calendarTest');
 const codexSearch = require('./codex-search');
 const dependencies = require('./dependencies');
 const exercise = require('./exercise');
-const inventorySearch = require('./inventorySearch');
+// const inventorySearch = require('./inventorySearch');
 const loanRenewal = require('./loan_renewal');
-const location = require('./location');
-const profilePictures = require('./profile-pictures');
-const stub = require('./stub');
+// const location = require('./location');
+// const profilePictures = require('./profile-pictures');
+// const stub = require('./stub');
 // const vendor = require('./vendor');
 
 
 module.exports.test = (uiTestCtx) => {
   const allTests = [
-    startPage,
-    authSuccess,
+    // startPage,
+    // authSuccess,
     authFail,
     codexSearch,
     dependencies,
     exercise,
-    inventorySearch,
+    // inventorySearch,
     loanRenewal,
-    location,
-    profilePictures,
-    stub,
+    // location,
+    // profilePictures,
+    // stub,
     // TODO: Move these. They are not included in platform-core
     // calendarTest,
     // vendor


### PR DESCRIPTION
The failing tests from platform-core are not actually invoked by ui-testing to begin with.  Therefore all tests not currently run by ui-testing have been disabled.
