### PR TITLE
Update snapshot for stripes framework v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,28 +18,27 @@
     "lint": "eslint test/ui-testing"
   },
   "dependencies": {
-    "@folio/checkin": ">=0.0.0",
-    "@folio/checkout": ">=0.0.0",
-    "@folio/circulation": ">=0.0.0",
-    "@folio/developer": ">=0.0.0",
-    "@folio/inventory": ">=0.0.0",
-    "@folio/myprofile": ">=0.0.0",
-    "@folio/organization": ">=0.0.0",
-    "@folio/plugin-find-instance": ">=0.0.0",
-    "@folio/plugin-find-user": ">=0.0.0",
-    "@folio/requests": ">=0.0.0",
-    "@folio/search": ">=0.0.0",
-    "@folio/servicepoints": ">=0.0.0",
-    "@folio/stripes": ">=0.0.0",
-    "@folio/stripes-core": ">=0.0.0",
-    "@folio/stripes-components": ">=0.0.0",
-    "@folio/tags": ">=0.0.0",
-    "@folio/users": ">=0.0.0"
+    "@folio/checkin": ">=1.3.0",
+    "@folio/checkout": ">=1.3.0",
+    "@folio/circulation": ">=1.3.0",
+    "@folio/developer": ">=1.5.0",
+    "@folio/inventory": ">=1.4.0",
+    "@folio/myprofile": ">=1.1.0",
+    "@folio/organization": ">=2.5.1",
+    "@folio/plugin-find-instance": ">=1.1.0",
+    "@folio/plugin-find-user": ">=1.3.0",
+    "@folio/requests": ">=1.4.1",
+    "@folio/search": ">=1.3.0",
+    "@folio/servicepoints": ">=1.1.0",
+    "@folio/stripes": "^1.0.0",
+    "@folio/tags": ">=1.1.0",
+    "@folio/users": ">=2.17.0",
+    "react": "^16.3.0"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": ">=0.0.0",
+    "@folio/eslint-config-stripes": ">=2.0.0",
+    "@folio/stripes-cli": ">=1.5.0",
     "eslint": "^4.19.1",
-    "moment": "^2.22.2",
-    "@folio/stripes-cli": ">=0.0.0"
+    "moment": "^2.22.2"
   }
 }


### PR DESCRIPTION
This updates the snapshot branch for stripes framework v1.  Rather than use >=0.0.0, I've applied the minimum versions of dependencies required to be compatible with stripes-framework v1, such as:
```
"@folio/users": ">=2.17.0",
```

Stripes framework uses the caret syntax to help guard against any future breaking changes leaking into the snapshot branch before they are ready for use in a platform.
```
"@folio/stripes": "^1.0.0",
```