### PR TITLE
simplify codex tests

### DIFF
--- a/test/ui-testing/codex-search.js
+++ b/test/ui-testing/codex-search.js
@@ -5,41 +5,47 @@ module.exports.test = (uiTestCtx) => {
     const nightmare = new Nightmare(config.nightmare);
 
     const title = 'Bridget Jones';
-    // const pageLoadPeriod = 2000;
-    const actionLoadPeriod = 222;
-    // const titleSortSelector = '#clickable-list-column-title';
-    const firstResultSelector = '#list-search div[role="listitem"] div[role="gridcell"]:nth-of-type(2)';
-    // const resultCountSelector = '#paneHeaderpane-results-subtitle span';
-    const filterCheckBoxSelector = '#clickable-filter-type-Audio';
-    const resetButtonLabel = 'Reset all';
-    const resetButtonSelector = '#clickable-reset-all';
+    let resultCount = 0;
 
-    describe('Login > Codex Search > Confirm Results > *Sorting Results (Not working currently)* > Filtering Results > Reset Search > Confirm Reset > Logout\n', () => {
+    describe('Login > Codex Search > Filtering Results > Reset Search > Logout\n', () => {
       it(`should login as ${config.username}/${config.password}`, (done) => {
         helpers.login(nightmare, config, done);
       });
 
       it('should open codex search and execute search', (done) => {
         nightmare
+          .wait('#clickable-search-module')
           .click('#clickable-search-module')
+          .wait('#input-record-search')
+          .type('#input-record-search', 'a')
+          .wait('#clickable-reset-all')
+          .click('#clickable-reset-all')
+          .wait('#input-record-search-qindex')
+          .select('#input-record-search-qindex', 'title')
           .wait('#input-record-search')
           .type('#input-record-search', title)
           .wait('button[type=submit]')
           .click('button[type=submit]')
-          .wait(`#list-search div[role="listitem"] a[aria-label*="${title}"]`)
-          .then(done)
+          .wait('#list-search:not([data-total-count="0"])')
+          .evaluate(() => {
+            return document.querySelector('#list-search').getAttribute('data-total-count');
+          })
+          .then((result) => {
+            nightmare
+              .then(done)
+              .catch(done);
+            resultCount = result;
+          })
           .catch(done);
       });
 
-      it('should confirm search results', (done) => {
+      it('should filter results and change result-count', (done) => {
         nightmare
-          .wait(firstResultSelector)
-          .evaluate((selector, itemTitle) => {
-            const firstResult = document.querySelector(selector).textContent; // the entered title should be the first result
-            if (firstResult.indexOf(itemTitle) === -1) {
-              throw new Error(`Title not found in first position. Title found is (${firstResult})`);
-            }
-          }, firstResultSelector, title)
+          .wait('#clickable-filter-type-Audiobooks')
+          .click('#clickable-filter-type-Audiobooks')
+          .wait(`#list-search:not([data-total-count="${resultCount}"])`)
+          .click('#clickable-filter-type-Audiobooks')
+          .wait(`#list-search[data-total-count="${resultCount}"]`)
           .then(done)
           .catch(done);
       });
@@ -75,96 +81,16 @@ module.exports.test = (uiTestCtx) => {
       //     .catch(done);
       // });
 
-      /* NE, 2018-06-13:
-         Disabled until further as it inexplicably fails on snapshot (and sometimes on testing iirc)
-         I can at times reproduce it from home on the first try against a new snapshot build, but it usually
-         passes in subsequent runs, making it all but impossible to experiment with it in one sitting.
-         Will instead try with, like, one or two test runs per day, while tweaking test code and logging.
-      it('should filter results', (done) => {
-
-        nightmare
-          .evaluate(resultSelectorBeforeClick => {
-            const matchBeforClick = document.querySelector(resultSelectorBeforeClick);
-            const countTextBeforeClick = matchBeforClick.innerText;
-            return parseInt(countTextBeforeClick.substr(0, countTextBeforeClick.indexOf(' ')), 10);
-          }, resultCountSelector)
-          .then((resultCountBeforeClick) => {
-            nightmare
-              .click(filterCheckBoxSelector)
-              .waitUntilNetworkIdle()
-              .wait(1000)
-              .evaluate((filterCheckBoxSelector, resultSelectorAfterClick) => {
-                const filterCheckBox = document.querySelector(filterCheckBoxSelector);
-
-                if (!filterCheckBox.checked) {
-                  throw new Error(`Filter not activated: filterCheckBox.checked = ${filterCheckBox.checked}`);
-                }
-
-                const matchAfterClick = document.querySelector(resultSelectorAfterClick);
-                const countTextAfterClick = matchAfterClick.innerText;
-                return parseInt(countTextAfterClick.substr(0, countTextAfterClick.indexOf(' ')), 10);
-              }, filterCheckBoxSelector, resultCountSelector)
-              .then(resultCountAfterClick => {
-                if (resultCountBeforeClick <= resultCountAfterClick) {
-                  throw new Error(`Results were not reduced by filtering: resultCountBeforeClick: ${resultCountBeforeClick}, resultCountAfterClick: ${resultCountAfterClick}`);
-                }
-                done();
-              })
-              .catch(done);
-          })
-          .catch(done);
-      });
-      */
-
       it('should reset search', (done) => {
         nightmare
-          .evaluate(function rsearch(resetLabel, resetSelector) {
-            const matches = document.querySelectorAll(resetSelector);
-            let found = false;
-            if (matches.length === 0) {
-              throw new Error('No buttons found');
+          .wait('#clickable-reset-all')
+          .click('#clickable-reset-all')
+          .evaluate(() => {
+            const results = document.querySelector('#list-search');
+            if (results) {
+              throw new Error('Found unexpected search results after reset');
             }
-            matches.forEach(function codexClick(currentValue) {
-              if (currentValue.textContent === resetLabel) {
-                currentValue.click();
-                found = true;
-              }
-            });
-            if (!found) {
-              throw new Error('Reset all button not found');
-            }
-          }, resetButtonLabel, resetButtonSelector)
-          .then(done)
-          .catch(done);
-      });
-
-      it('should confirm reset search', (done) => {
-        // #input-record-search should be empty and Reset all disappears
-        nightmare
-          .wait(actionLoadPeriod)
-          .evaluate(function confReset(selector) {
-            const searchField = document.querySelector(selector);
-            if (searchField.value.length > 0) {
-              throw new Error('Input field not cleared on reset');
-            }
-          }, '#input-record-search')
-          .evaluate(function confResetAgain(resetSelector) {
-            const matches = document.querySelectorAll(resetSelector);
-            matches.forEach(function confResetEach(currentValue) {
-              if (!currentValue.disabled) {
-                throw new Error('Reset all button is visible. '
-                  + 'Content: ' + currentValue.textContent
-                  + ' ID: ' + currentValue.id
-                  + ' Disabled: ' + currentValue.disabled);
-              }
-            });
-          }, resetButtonSelector)
-          .evaluate(function confResetOfFilters(resetSelector) {
-            const filterCheckBox = document.querySelector(resetSelector);
-            if (filterCheckBox.checked) {
-              throw new Error('Filters have not been reset.');
-            }
-          }, filterCheckBoxSelector)
+          })
           .then(done)
           .catch(done);
       });


### PR DESCRIPTION
Simplify the code to evaluate the success of the filters, and accommodate the fact that the codex will likely return many records for any given search now that we have eholdings enabled.