### PR TITLE
store proxy's barcode, not username

### DIFF
--- a/test/ui-testing/new_proxy.js
+++ b/test/ui-testing/new_proxy.js
@@ -57,7 +57,7 @@ module.exports.test = function foo(uiTestCtx, nightmare) {
       });
 
       it('should add a proxy for user 1', (done) => {
-        const selector = '#OverlayContainer #list-users div[role="listitem"]:nth-child(1) div[role=gridcell]:nth-child(4)';
+        const selector = '#OverlayContainer #list-users div[role="listitem"]:nth-child(1) div[role=gridcell]:nth-child(5)';
         nightmare
           .wait('#input-user-search')
           .type('#input-user-search', '0')


### PR DESCRIPTION
barcodes are likely to be unique across the system, but usernames (or
portions thereof) may turn up in other users' names. Because the
user-search feature includes username, first name, last name, and email,
this means that while the username itself may be unique, a search for it
may turn up multiple rows.

Fixes [FOLIO-1657](https://issues.folio.org/browse/FOLIO-1657)