### PR TITLE
instantiate new Nightmare instance for tests

### DIFF
--- a/test/ui-testing/120-auth-fail.js
+++ b/test/ui-testing/120-auth-fail.js
@@ -1,6 +1,8 @@
-module.exports.test = (uiTestCtx, nightmare) => {
+module.exports.test = (uiTestCtx, nightmareX) => {
   describe('Login Page ("test-bad-login")', function test() {
     const { config } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
+
     this.timeout(Number(config.test_timeout));
     describe('given bad data', () => {
       it('Should find a login error message', (done) => {
@@ -9,6 +11,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
           .wait(config.select.username)
           .insert(config.select.username, 'notgonnawork')
           .insert(config.select.password, 'invalid password')
+          .wait('#clickable-login')
           .click('#clickable-login')
           .wait('div[class^="AuthErrorsContainer"]') // failure
           .then(done)

--- a/test/ui-testing/codex-search.js
+++ b/test/ui-testing/codex-search.js
@@ -1,6 +1,7 @@
-module.exports.test = (uiTestCtx, nightmare) => {
+module.exports.test = (uiTestCtx, nightmareX) => {
   describe('Load test-codexsearch', function runMain() {
     const { config, helpers } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
     const title = 'Bridget Jones';
@@ -95,7 +96,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
       });
 
       it('should logout', (done) => {
-        helpers.logoutWithoutEnd(nightmare, config, done);
+        helpers.logout(nightmare, config, done);
       });
     });
   });

--- a/test/ui-testing/dependencies.js
+++ b/test/ui-testing/dependencies.js
@@ -1,12 +1,15 @@
-module.exports.test = (uiTestCtx, nightmare) => {
+module.exports.test = (uiTestCtx, nightmareX) => {
   describe('Checking for dependency issues on FOLIO UI App /about ("test-dependencies")', function start() {
     const { config, helpers } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
+
     this.timeout(Number(config.test_timeout));
 
     describe('Login > Click "About" link > Check for dependency errors > Logout\n', () => {
       it('should login', (done) => {
         helpers.login(nightmare, config, done);
       });
+
       it('should load "about" page', (done) => {
         nightmare
           .click('#clickable-settings')
@@ -15,6 +18,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
           .then(() => { done(); })
           .catch(done);
       });
+
       it('should check for "red" errors', (done) => {
         nightmare
           .evaluate(() => {
@@ -38,6 +42,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
           })
           .catch(done);
       });
+
       it('should check for "orange" errors', (done) => {
         nightmare
           .evaluate(() => {
@@ -61,8 +66,9 @@ module.exports.test = (uiTestCtx, nightmare) => {
           })
           .catch(done);
       });
+
       it('should logout', (done) => {
-        helpers.logoutWithoutEnd(nightmare, config, done);
+        helpers.logout(nightmare, config, done);
       });
     });
   });

--- a/test/ui-testing/exercise.js
+++ b/test/ui-testing/exercise.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^type" }] */
 
-module.exports.test = (uiTestCtx, nightmare) => {
+module.exports.test = (uiTestCtx, nightmareX) => {
   describe('Exercise users, inventory, checkout, checkin, settings ("test-exercise")', function descRoot() {
     const { config, helpers } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
     const findUserNameCell = (username) => {
@@ -236,7 +237,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
       });
 
       it('should logout', (done) => {
-        helpers.logoutWithoutEnd(nightmare, config, done);
+        helpers.logout(nightmare, config, done);
       });
     });
   });

--- a/test/ui-testing/loan_renewal.js
+++ b/test/ui-testing/loan_renewal.js
@@ -2,9 +2,10 @@
 
 const moment = require('moment');
 
-module.exports.test = (uiTestCtx, nightmare) => {
+module.exports.test = (uiTestCtx, nightmareX) => {
   describe('Tests to validate the loan renewals', function descRoot() {
     const { config, helpers } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
     this.timeout(Number(config.test_timeout));
 
     // note the comparison uses string interpolation because we want to
@@ -581,7 +582,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
       });
 
       it('should logout', (done) => {
-        helpers.logoutWithoutEnd(nightmare, config, done);
+        helpers.logout(nightmare, config, done);
       });
     });
   });

--- a/test/ui-testing/new_proxy.js
+++ b/test/ui-testing/new_proxy.js
@@ -1,7 +1,8 @@
 /* global it describe Nightmare before after */
-module.exports.test = function foo(uiTestCtx, nightmare) {
+module.exports.test = function foo(uiTestCtx, nightmareX) {
   describe('Module test: new_proxy', function bar() {
-    const { config, helpers: { login, openApp, logoutWithoutEnd }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, openApp, logout }, meta: { testVersion } } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
 
     this.timeout(Number(config.test_timeout));
 
@@ -12,7 +13,7 @@ module.exports.test = function foo(uiTestCtx, nightmare) {
         login(nightmare, config, done); // logs in with the default admin credentials
       });
       after((done) => {
-        logoutWithoutEnd(nightmare, config, done);
+        logout(nightmare, config, done);
       });
 
       it('should open app and find version tag', (done) => {


### PR DESCRIPTION
Using the passed-in instance of Nightmare leads to weird, weird results
where tests seem to run interleaved with one another and things
generally fall apart in strange, unpredictable ways that ultimately
result in tests that fail when run as part of a suite but succeed when
run individually.

It's like the instance of Nightmare gets tired and just can't keep
itself together. Sadly, this means we can't use Nightmare to collect
coverage data since it's using that single instance that allows us to
generate that data. Alas.

Fixes [FOLIO-1660](https://issues.folio.org/browse/FOLIO-1660)