### PR TITLE
restore end

### DIFF
--- a/test/ui-testing/120-auth-fail.js
+++ b/test/ui-testing/120-auth-fail.js
@@ -14,6 +14,7 @@ module.exports.test = (uiTestCtx, nightmareX) => {
           .wait('#clickable-login')
           .click('#clickable-login')
           .wait('div[class^="AuthErrorsContainer"]') // failure
+          .end()
           .then(done)
           .catch(done);
       });


### PR DESCRIPTION
`end()` is required to terminate the Nightmare instance.

Fixes [FOLIO-1662](https://issues.folio.org/browse/FOLIO-1662)