### PR TITLE
Add third-party dependencies per Stripes v1.1 recommendation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "@folio/servicepoints": "~1.2.0",
     "@folio/stripes": "~1.1.0",
     "@folio/tags": "~1.2.0",
-    "@folio/users": "~2.18.0"
+    "@folio/users": "~2.18.0",
+    "react": "~16.6.3",
+    "react-dom": "~16.6.3",
+    "react-redux": "~5.1.1",
+    "redux": "~3.7.2"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",


### PR DESCRIPTION
As discovered late last week, @zburke found under certain conditions (perhaps limited to workspace installs) multiple versions of React can surface causing a build error.  This is due to React missing in the platform (currently present in snapshot).  Without React in the root package.json, peerDependency requirements for React within the ui-modules are not guaranteed.

Although they don't appear to have caused issue yet, this PR also adds the other related third-party dependencies to the platform as specified in the Stripes v1.1 upgrade.
https://github.com/folio-org/stripes/blob/master/doc/stripes-framework.md#upgrading-to-v11