### PR TITLE
Add third-party dependencies per Stripes v1.1 recommendation

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,10 +50,13 @@
     "@folio/requests": ">=1.4.1",
     "@folio/search": ">=1.3.0",
     "@folio/servicepoints": ">=1.1.0",
-    "@folio/stripes": "^1.0.0",
+    "@folio/stripes": "^1.1.0",
     "@folio/tags": ">=1.1.0",
     "@folio/users": ">=2.17.0",
-    "react": "^16.3.0"
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
+    "react-redux": "^5.1.1",
+    "redux": "^3.7.2"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",


### PR DESCRIPTION
Related to #138.  However with this being snapshot, I used `^` versions rather than `~` since we were already doing that with `stripes` itself.