### PR TITLE
include required dependencies in platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
     "@folio/servicepoints": "~1.2.0",
     "@folio/stripes": "~1.1.0",
     "@folio/tags": "~1.2.0",
-    "@folio/users": "~2.18.0"
+    "@folio/users": "~2.18.0", 
+    "react": "~16.6.0",
+    "react-dom": "~16.6.0", 
+    "react-redux": "~5.1.1", 
+    "redux": "~3.7.2"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",


### PR DESCRIPTION
Per the stripes documentation, the platform must declare the
dependencies that other packages depend on.

See https://github.com/folio-org/stripes/blob/master/doc/stripes-framework.md#upgrading-to-v11