### PR TITLE
Remove duplicate devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,6 @@
     "@folio/eslint-config-stripes": "^3.2.1",
     "@folio/stripes-cli": ">=1.5.0",
     "eslint": "^5.6.1",
-    "react": "~16.6.0",
-    "react-dom": "~16.6.0", 
-    "react-redux": "~5.1.1", 
-    "redux": "~3.7.2",
     "moment": "^2.22.2"
   }
 }


### PR DESCRIPTION
Resolves these warnings introduced in https://github.com/folio-org/platform-core/pull/151:
```
warning package.json: "dependencies" has dependency "react" with range "^16.6.3" that collides with a dependency in "devDependencies" of the same name with version "~16.6.0"
warning package.json: "dependencies" has dependency "react-dom" with range "^16.6.3" that collides with a dependency in "devDependencies" of the same name with version "~16.6.0"
warning package.json: "dependencies" has dependency "react-redux" with range "^5.1.1" that collides with a dependency in "devDependencies" of the same name withversion "~5.1.1"
warning package.json: "dependencies" has dependency "redux" with range "^3.7.2" that collides with a dependency in "devDependencies" of the same name with version "~3.7.2"
```