### PR TITLE
Release v1.3.0 snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change history for platform-core
 
-## 1.2.0 (IN PROGRESS)
+## 1.4.0 (IN PROGRESS)
+
+
+## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
+
+* Upgrade to `stripes` framework `v2.0.0`, STRIPES-577
+
+
+## [1.2.2](https://github.com/folio-org/platform-core/tree/v1.2.2-SNAPSHOT) (2019-01-17)
 
 * Manually click the search button in tests. Refs STCOM-354.
 * Don't use the search button in OverlayContainers; that submits the underlying forms in addition.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/platform-core",
-  "version": "1.2.2-SNAPSHOT",
+  "version": "1.3.0-SNAPSHOT",
   "license": "Apache-2.0",
   "repository": "folio-org/platform-core",
   "publishConfig": {
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes-cli": ">=1.5.0",
+    "@folio/stripes-cli": ">=1.8.0",
     "eslint": "^5.6.1",
     "moment": "^2.22.2"
   }


### PR DESCRIPTION
This branch already has been upgraded to stripes 2.0.0.  This PR bumps the version to have something to tag/release and later include in platform-complete snapshot.