### PR TITLE
complete request form in order

### DIFF
--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -51,6 +51,7 @@ module.exports.test = function uiTest(uiTestCtx) {
 
       it('should check out newly created item', (done) => {
         nightmare
+          .wait(1111)
           .wait('#clickable-checkout-module')
           .click('#clickable-checkout-module')
           .wait('#section-patron #clickable-find-user')
@@ -75,15 +76,17 @@ module.exports.test = function uiTest(uiTestCtx) {
 
       it('should add a new "Hold" request', (done) => {
         nightmare
+          .wait(1111)
+          .wait('#clickable-requests-module')
           .click('#clickable-requests-module')
           .wait('#clickable-newrequest')
           .click('#clickable-newrequest')
-          .wait('select[name="requestType"]')
-          .select('select[name="requestType"]', 'Hold')
           .insert('input[name="item.barcode"]', itembc)
           .wait('#clickable-select-item')
           .click('#clickable-select-item')
           .wait('#section-item-info a[href^="/inventory/view/"]')
+          .wait('select[name="requestType"]')
+          .select('select[name="requestType"]', 'Hold')
           .wait('input[name="requester.barcode"]')
           .insert('input[name="requester.barcode"]', userbc)
           .wait('#clickable-select-requester')


### PR DESCRIPTION
Fields in the request form were recently rearranged such that it is now
necessary to choose an item before setting the request type. The test
test did not reflect this new order, but now it does.

Refs [STRIPES-602](https://issues.folio.org/browse/STRIPES-602), [UIREQ-208](https://issues.folio.org/browse/UIREQ-208)