### PR TITLE
use always-available settings identifier

### DIFF
--- a/test/ui-testing/dependencies.js
+++ b/test/ui-testing/dependencies.js
@@ -12,7 +12,7 @@ module.exports.test = (uiTestCtx) => {
 
       it('should load "about" page', (done) => {
         nightmare
-          .click('#clickable-settings')
+          .click('#app-list-item-clickable-settings')
           .click('a[href="/settings/about"]')
           .wait(555)
           .then(() => { done(); })

--- a/test/ui-testing/profile-pictures.js
+++ b/test/ui-testing/profile-pictures.js
@@ -32,7 +32,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
 
       it('should enable profile pictures', (done) => {
         nightmare
-          .click('#clickable-settings')
+          .click('#app-list-item-clickable-settings')
           .wait('a[href="/settings/users"]')
           .click('a[href="/settings/users"]')
           .wait('a[href="/settings/users/profilepictures"]')
@@ -100,7 +100,7 @@ module.exports.test = (uiTestCtx, nightmare) => {
 
       it('should disable profile pictures', (done) => {
         nightmare
-          .click('#clickable-settings')
+          .click('#app-list-item-clickable-settings')
           .wait(pageLoadPeriod)
           .evaluate(() => {
             const elem = document.querySelector('#profile_pictures');


### PR DESCRIPTION
The `clickable-settings` button may not always be available in the UI.
Specifically if there are more than 11 apps in the bundle, then it will
not be available. But there's still hope! The element in the apps menu
_is_ always available, and this change updates tests to find that
element instead.

Refs [STRIPES-606](https://issues.folio.org/browse/STRIPES-606)