### PR TITLE
don't click on things in browser scope

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -32,15 +32,18 @@ module.exports.test = (uiTestCtx) => {
 
     const renewalLimit = 1;
     const loanPeriod = 2;
+
+    // note the format MUST match that expected by the locale
+    // otherwise the fixed-due-date-schedule dates will not register
     const nextMonthValue = moment()
       .add(65, 'days')
-      .format('YYYY-MM-DD');
+      .format('MM/DD/YYYY');
     const tomorrowValue = moment()
       .add(3, 'days')
-      .format('YYYY-MM-DD');
+      .format('MM/DD/YYYY');
     const dayAfterValue = moment()
       .add(4, 'days')
-      .format('YYYY-MM-DD');
+      .format('MM/DD/YYYY');
     const debugSleep = parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 0;
     let loanRules = '';
     let barcode = '';
@@ -80,6 +83,10 @@ module.exports.test = (uiTestCtx) => {
         describe('Update settings', () => {
           it('should configure checkout for barcode and username', (done) => {
             helpers.circSettingsCheckoutByBarcodeAndUsername(nightmare, config, done);
+          });
+
+          it('should configure US English locale and timezone', (done) => {
+            helpers.setUsEnglishLocale(nightmare, config, done);
           });
         });
 
@@ -616,26 +623,34 @@ module.exports.test = (uiTestCtx) => {
               .wait('a[href="/settings/circulation/loan-policies"]')
               .click('a[href="/settings/circulation/loan-policies"]')
               .wait('div.hasEntries')
-              .evaluate((pn) => {
-                const node = Array.from(
+              .wait((pn) => {
+                const index = Array.from(
                   document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                )
-                  .find(e => e.textContent === pn);
-                if (node) {
-                  node.parentElement.click();
-                } else {
-                  throw new Error(`Could not find the loan policy ${pn} to edit`);
-                }
+                ).findIndex(e => e.textContent === pn);
+                return index >= 0;
               }, policyName)
-              .then(() => {
+              .evaluate((pn) => {
+                const index = Array.from(
+                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+                ).findIndex(e => e.textContent === pn);
+                if (index === -1) {
+                  throw new Error(`Could not find the loan policy ${pn} to delete`);
+                }
+
+                // CSS selectors are 1-based, which is just totally awesome.
+                return index + 1;
+              }, policyName)
+              .then((entryIndex) => {
                 nightmare
+                  .wait(`#ModuleContainer div.hasEntries a:nth-of-type(${entryIndex})`)
+                  .click(`#ModuleContainer div.hasEntries a:nth-of-type(${entryIndex})`)
                   .wait('#clickable-edit-item')
                   .click('#clickable-edit-item')
                   .wait('#clickable-delete-entry')
                   .click('#clickable-delete-entry')
                   .wait('#clickable-delete-item-confirmation-confirm')
                   .click('#clickable-delete-item-confirmation-confirm')
-                  .wait(3000)
+                  .wait('#clickable-edit-item')
                   .then(done)
                   .catch(done);
               })


### PR DESCRIPTION
avoid clicking links in browser scope. instead, try even harder to
figure out a CSS selector for the thing to be clicked and pass that back
to Nightmare and let Nightmare click it. That seems to make Nightmare
happy, and does a better job of avoiding the problem of Nightmare
getting lost in the never neverland of parallel execution.

Of course, this isn't completely true as the 'renew loan' checkboxes
are, strangely, unclickable in Nightmare's scope. WTF?