### PR TITLE
use locale-formatted dates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,6 +150,15 @@ pipeline {
           }
           steps {
             script {
+              def commitStatus
+
+              sh "git add ${env.WORKSPACE}/stripes-install.json"
+              sh "git add ${env.WORKSPACE}/okapi-install.json"
+              sh "git add ${env.WORKSPACE}/install.json"
+              sh "git add ${env.WORKSPACE}/yarn.lock"
+              commitStatus = sh(returnStatus: true,
+                                script: 'git commit -m "[CI SKIP] Updating install files in PR branch"')
+
               sh "git fetch --no-tags ${env.projUrl} " +
                  "+refs/heads/${env.CHANGE_BRANCH}:refs/remotes/origin/${env.CHANGE_BRANCH}"
               sh "git checkout -b ${env.CHANGE_BRANCH} origin/${env.CHANGE_BRANCH}"
@@ -159,8 +168,8 @@ pipeline {
               sh "git add ${env.WORKSPACE}/install.json"
               sh "git add ${env.WORKSPACE}/yarn.lock"
 
-              def commitStatus = sh(returnStatus: true,
-                                    script: 'git commit -m "[CI SKIP] Updating install files"')
+              commitStatus = sh(returnStatus: true,
+                                    script: 'git commit -m "[CI SKIP] Updating install files on branch"')
               if (commitStatus == 0) {
                 sshGitPush(origin: env.folioPlatform, branch: env.CHANGE_BRANCH)
               }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@folio/calendar": "~2.1.0",
     "@folio/checkin": "~1.6.0",
     "@folio/checkout": "~1.7.0",
-    "@folio/circulation": "~1.6.0",
+    "@folio/circulation": "~1.6.1",
     "@folio/developer": "~1.7.0",
     "@folio/inventory": "~1.7.0",
     "@folio/myprofile": "~1.5.0",

--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -32,15 +32,17 @@ module.exports.test = (uiTestCtx) => {
 
     const renewalLimit = 1;
     const loanPeriod = 2;
+    // note the format MUST match that expected by the locale
+    // otherwise the fixed-due-date-schedule dates will not register
     const nextMonthValue = moment()
       .add(65, 'days')
-      .format('YYYY-MM-DD');
+      .format('MM/DD/YYYY');
     const tomorrowValue = moment()
       .add(3, 'days')
-      .format('YYYY-MM-DD');
+      .format('MM/DD/YYYY');
     const dayAfterValue = moment()
       .add(4, 'days')
-      .format('YYYY-MM-DD');
+      .format('MM/DD/YYYY');
     const debugSleep = parseInt(process.env.FOLIO_UI_DEBUG, 10) ? parseInt(config.debug_sleep, 10) : 0;
     let loanRules = '';
     let barcode = '';
@@ -80,6 +82,37 @@ module.exports.test = (uiTestCtx) => {
         describe('Update settings', () => {
           it('should configure checkout for barcode and username', (done) => {
             helpers.circSettingsCheckoutByBarcodeAndUsername(nightmare, config, done);
+          });
+
+          it('should configure US English locale and timezone', (done) => {
+            nightmare
+              .wait(config.select.settings)
+              .click(config.select.settings)
+              .wait('a[href="/settings/organization"]')
+              .click('a[href="/settings/organization"]')
+              .wait('a[href="/settings/organization/locale"]')
+              .click('a[href="/settings/organization/locale"]')
+              .wait('#locale')
+              .select('#locale', 'en-US')
+              .wait('#timezone')
+              .select('#timezone', 'America/New_York')
+              .wait(1000)
+              .exists('#clickable-save-config[type=submit]:enabled')
+              .then((hasChanged) => {
+                if (hasChanged) {
+                  nightmare
+                    .click('#clickable-save-config')
+                    .wait('#clickable-save-config[type=submit]:disabled')
+                    // saving the locale has a 2s timout and we want to
+                    // make sure we wait for that to finish
+                    .wait(4000)
+                    .then(done)
+                    .catch(done);
+                } else {
+                  done();
+                }
+              })
+              .catch(done);
           });
         });
 


### PR DESCRIPTION
`<DatePicker>` now supports locale-formatted dates. You get these
automatically when using the UI to select a date, but when pasting a
string into the field it must be correctly formatted to match the
locale.

Release v1.6.1 of ui-circulation incorporates the `<DatePicker>` changes
which are reflected in the updated test here that sets a specific locale
and then uses dates formatted for that locale.