### PR TITLE
provide react 16.8, the one with hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "@folio/stripes": "^2.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/users": ">=2.17.0",
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
     "react-redux": "^5.1.1",
     "redux": "^3.7.2"
   },


### PR DESCRIPTION
Provide a current release of React, v16.8, the one with hooks.

Refs [STRIPES-599](https://issues.folio.org/browse/STRIPES-599)