### PR TITLE
better delete/wait handling

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -676,7 +676,6 @@ module.exports.test = (uiTestCtx) => {
                       document.querySelectorAll('#OverlayContainer div[class^="calloutBase"]')
                     ).findIndex(e => e.textContent === `The Loan policy ${pn} was successfully deleted.`) >= 0;
                   }, policyName)
-                  .wait('#clickable-edit-item')
                   .then(done)
                   .catch(done);
               })


### PR DESCRIPTION
Don't wait for edit-button when confirming delete. After the delete is
processed, no loan-item will be selected, hence no edit-button will be
available. The `.wait('#clickable-edit-item')` line was left over from a
previous incarnation of the tests. It didn't cause trouble in other test
environments where the test must breeze past it while still showing the
policy's details, but for some reason it doesn't work that way in CI.

Refs [UICIRC-237](https://issues.folio.org/browse/UICIRC-237)