### PR TITLE
choose active users only

### DIFF
--- a/test/ui-testing/exercise.js
+++ b/test/ui-testing/exercise.js
@@ -53,6 +53,8 @@ module.exports.test = (uiTestCtx) => {
         nightmare
           .wait('#clickable-users-module')
           .click('#clickable-users-module')
+          .wait('#clickable-filter-active-active')
+          .click('#clickable-filter-active-active')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
           .wait('#list-users:not([data-total-count="0"])')

--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -266,6 +266,8 @@ module.exports.test = (uiTestCtx) => {
               .type('#input-user-search', '0')
               .wait('#clickable-reset-all')
               .click('#clickable-reset-all')
+              .wait('#clickable-filter-active-active')
+              .click('#clickable-filter-active-active')
               .wait('#clickable-filter-pg-faculty')
               .click('#clickable-filter-pg-faculty')
               .wait(uselector)

--- a/test/ui-testing/new-proxy.js
+++ b/test/ui-testing/new-proxy.js
@@ -31,6 +31,8 @@ module.exports.test = function foo(uiTestCtx) {
           .type('#input-user-search', '0')
           .wait('#clickable-reset-all')
           .click('#clickable-reset-all')
+          .wait('#clickable-filter-active-active')
+          .click('#clickable-filter-active-active')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
           .wait('#list-users div[role="row"][aria-rowindex="2"]')
@@ -82,6 +84,8 @@ module.exports.test = function foo(uiTestCtx) {
           // but clicking the "search" button in the modal submits
           // the underlying user-edit form in addition to this form,
           // so we lose the ability to capture the proxy we just found.
+          .wait('#OverlayContainer #clickable-filter-active-active')
+          .click('#OverlayContainer #clickable-filter-active-active')
           .wait('#OverlayContainer #clickable-filter-pg-undergrad')
           .click('#OverlayContainer #clickable-filter-pg-undergrad')
           .wait('#OverlayContainer #list-plugin-find-user:not([data-total-count="0"])')
@@ -90,8 +94,8 @@ module.exports.test = function foo(uiTestCtx) {
           }, selector)
           .then(barcode => {
             nightmare
-              .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"] a')
-              .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"] a')
+              .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
+              .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
               .wait('#clickable-updateuser')
               .click('#clickable-updateuser')
               .then(done)

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -11,7 +11,7 @@ module.exports.test = function uiTest(uiTestCtx) {
 
     describe('Login > Open module "Requests" > Create new request > Logout', () => {
       let userbc = null;
-      let userbcReqeustor = null;
+      let userbcRequestor = null;
       const nextMonthValue = new Date().valueOf() + 2419200000;
       const nextMonth = new Date(nextMonthValue).toLocaleDateString('en-US');
       before((done) => {
@@ -85,6 +85,10 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait(1111)
           .wait('#clickable-users-module')
           .click('#clickable-users-module')
+          .wait('#OverlayContainer #clickable-filter-pg-undergrad')
+          .click('#OverlayContainer #clickable-filter-pg-undergrad')
+          .wait('#clickable-filter-active-active')
+          .click('#clickable-filter-active-active')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
           .wait('#list-users:not([data-total-count="0"])')
@@ -94,8 +98,8 @@ module.exports.test = function uiTest(uiTestCtx) {
           }, bcodeNode)
           .then((result) => {
             done();
-            userbcReqeustor = result;
-            console.log(`        Found ${userbc}`);
+            userbcRequestor = result;
+            console.log(`        Found ${userbcRequestor}`);
           })
           .catch(done);
       });
@@ -111,7 +115,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait('#OverlayContainer #clickable-filter-pg-faculty')
           .click('#OverlayContainer #clickable-filter-pg-faculty')
           .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
-          .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"] a')
+          .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
           .wait(2222)
           .wait('#input-item-barcode')
           .insert('#input-item-barcode', itembc)
@@ -140,7 +144,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait('select[name="requestType"]')
           .select('select[name="requestType"]', 'Hold')
           .wait('input[name="requester.barcode"]')
-          .insert('input[name="requester.barcode"]', userbcReqeustor)
+          .insert('input[name="requester.barcode"]', userbcRequestor)
           .wait('#clickable-select-requester')
           .click('#clickable-select-requester')
           .wait('#section-requester-info a[href^="/users/view/"]')

--- a/test/ui-testing/profile-pictures.js
+++ b/test/ui-testing/profile-pictures.js
@@ -76,6 +76,8 @@ module.exports.test = (uiTestCtx, nightmare) => {
       it('should check picture present in user information', (done) => {
         nightmare
           .click('#clickable-users-module')
+          .wait('#clickable-filter-active-active')
+          .click('#clickable-filter-active-active')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
           .wait('#list-users')
@@ -139,6 +141,8 @@ module.exports.test = (uiTestCtx, nightmare) => {
           .click('#clickable-users-module')
           .wait('#users-module-display')
           // check on active users filter
+          .wait('#clickable-filter-active-active')
+          .click('#clickable-filter-active-active')
           .wait('#clickable-filter-pg-faculty')
           .click('#clickable-filter-pg-faculty')
           .wait('#list-users')


### PR DESCRIPTION
The active/inactive checkboxes were restored in folio-org/ui-users/pull/811
which means we need to check the 'active' checkbox when looking for
users, otherwise we'll get inactive users in the mix who don't have the
ability to, e.g., check out an item or place a request.

Refs [UITEST-64](https://issues.folio.org/browse/UITEST-64)