### PR TITLE
better user selection

### DIFF
--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -57,45 +57,42 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       it('should find an active user barcode for checkout', (done) => {
-        const listitem = '#list-users div[role="row"] > a';
-        const bcodeNode = `${listitem} > div:nth-child(3)`;
+        const listitem = '#list-users div[role="row"]:nth-of-type(2) > a div:nth-child(3)';
         nightmare
           .wait(1111)
           .wait('#clickable-users-module')
           .click('#clickable-users-module')
-          .wait('#clickable-filter-pg-undergrad')
-          .click('#clickable-filter-pg-undergrad')
+          .wait('#clickable-filter-active-active')
+          .click('#clickable-filter-active-active')
           .wait('#list-users:not([data-total-count="0"])')
-          .wait(listitem)
-          .evaluate((bcode) => {
-            return document.querySelector(bcode).textContent;
-          }, bcodeNode)
-          .then((result) => {
-            done();
-            userbc = result;
-            console.log(`        Found ${userbc}`);
+          .evaluate(() => {
+            return document.querySelector('#list-users').getAttribute('data-total-count');
+          })
+          .then((count) => {
+            nightmare
+              .wait('#clickable-filter-pg-undergrad')
+              .click('#clickable-filter-pg-undergrad')
+              .wait(`#list-users:not([data-total-count="${count}"])`)
+              .wait(listitem)
+              .evaluate((bcode) => {
+                return document.querySelector(bcode).textContent;
+              }, listitem)
+              .then((result) => {
+                done();
+                userbc = result;
+                console.log(`        Found ${userbc}`);
+              })
+              .catch(done);
           })
           .catch(done);
       });
 
       it('should find an active user barcode for request', (done) => {
-        const listitem = '#list-users div[role="row"] > a';
-        const bcodeNode = `${listitem} > div:nth-child(3)`;
+        const listitem = '#list-users div[role="row"]:nth-of-type(3) > a div:nth-child(3)';
         nightmare
-          .wait(1111)
-          .wait('#clickable-users-module')
-          .click('#clickable-users-module')
-          .wait('#clickable-filter-pg-undergrad')
-          .click('#clickable-filter-pg-undergrad')
-          .wait('#clickable-filter-active-active')
-          .click('#clickable-filter-active-active')
-          .wait('#clickable-filter-pg-faculty')
-          .click('#clickable-filter-pg-faculty')
-          .wait('#list-users:not([data-total-count="0"])')
-          .wait(listitem)
           .evaluate((bcode) => {
             return document.querySelector(bcode).textContent;
-          }, bcodeNode)
+          }, listitem)
           .then((result) => {
             done();
             userbcRequestor = result;
@@ -103,6 +100,7 @@ module.exports.test = function uiTest(uiTestCtx) {
           })
           .catch(done);
       });
+
       const itembc = createInventory(nightmare, config, 'Request title');
 
       it('should check out newly created item', (done) => {
@@ -110,13 +108,19 @@ module.exports.test = function uiTest(uiTestCtx) {
           .wait(1111)
           .wait('#clickable-checkout-module')
           .click('#clickable-checkout-module')
-          .wait('#section-patron #clickable-find-user')
-          .click('#section-patron #clickable-find-user')
-          .wait('#OverlayContainer #clickable-filter-pg-faculty')
-          .click('#OverlayContainer #clickable-filter-pg-faculty')
-          .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
-          .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
-          .wait(2222)
+          .wait('#input-patron-identifier')
+          .type('#input-patron-identifier', userbc)
+          .wait('#clickable-find-patron')
+          .click('#clickable-find-patron')
+          .wait(() => {
+            const err = document.querySelector('#patron-form div[class^="textfieldError"]');
+            const yay = !!document.querySelector('#patron-form ~ div a > strong');
+            if (err) {
+              throw new Error(err.textContent);
+            } else {
+              return yay;
+            }
+          })
           .wait('#input-item-barcode')
           .insert('#input-item-barcode', itembc)
           .wait('#clickable-add-item')


### PR DESCRIPTION
Oy selecting users when multiple filters are in place is a mess. The
original "wait for the count to be non-zero" selector no longer works
because the count becomes non-zero after the first filter is applied.
This means checking for a non-zero count after the second filter can
return true, allowing flow to move on while the list is still changing
because the second filter hasn't yet been applied.

This can result in selecting diku_admin, which has no barcode, or an
inactive user, who is not allowed to perform a checkout.