### PR TITLE
fix proxy tests

### DIFF
--- a/test/ui-testing/new-proxy.js
+++ b/test/ui-testing/new-proxy.js
@@ -94,8 +94,8 @@ module.exports.test = function foo(uiTestCtx) {
           }, selector)
           .then(barcode => {
             nightmare
-              .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"] a')
-              .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"] a')
+              .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
+              .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
               .wait('#clickable-save')
               .click('#clickable-save')
               .then(done)


### PR DESCRIPTION
ui-plugin-find-user does not wrap search result rows in `a` tags the way
ui-users does, and since the plugin no longer relies on ui-users under
the hood, the selector needs to be updated accordingly.