### PR TITLE
add tenant-settings to replace organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.4.0 (IN PROGRESS)
 
 * Update integration tests to accommodate MCL aria changes, STRIPES-596
+* Add ui-tenant-settings, the eventual replacement for ui-organization, UIORG-156
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@folio/inventory": ">=1.4.0",
     "@folio/myprofile": ">=1.1.0",
     "@folio/organization": ">=2.5.1",
+    "@folio/tenant-settings": ">=2.5.1",
     "@folio/plugin-find-instance": ">=1.1.0",
     "@folio/plugin-find-user": ">=1.3.0",
     "@folio/requests": ">=1.4.1",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -14,6 +14,7 @@ module.exports = {
     '@folio/inventory' : {},
     '@folio/myprofile' : {},
     '@folio/organization' : {},
+    '@folio/tenant-settings' : {},
     '@folio/plugin-find-instance' : {},
     '@folio/plugin-find-user' : {},
     '@folio/requests' : {},


### PR DESCRIPTION
Eventually, tenant-settings will replace organization. The first step is
to add tenant-settings.

Refs [UIORG-156](https://issues.folio.org/browse/UIORG-156)