### PR TITLE
purge openApp

### DIFF
--- a/test/ui-testing/new-proxy.js
+++ b/test/ui-testing/new-proxy.js
@@ -1,7 +1,7 @@
 /* global it describe Nightmare before after */
 module.exports.test = function foo(uiTestCtx) {
   describe('User proxies ("new-proxy")', function bar() {
-    const { config, helpers: { login, openApp, clickApp, logout }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, clickApp, logout } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
     this.timeout(Number(config.test_timeout));
@@ -14,13 +14,6 @@ module.exports.test = function foo(uiTestCtx) {
       });
       after((done) => {
         logout(nightmare, config, done);
-      });
-
-      it('should open app and find version tag', (done) => {
-        nightmare
-          .use(openApp(nightmare, config, done, 'users', testVersion))
-          .then(result => result)
-          .catch(done);
       });
 
       it('should navigate to users', (done) => {

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -2,7 +2,7 @@
 
 module.exports.test = function uiTest(uiTestCtx) {
   describe('New request ("new-request")', function modTest() {
-    const { config, helpers: { login, openApp, clickApp, clickSettings, createInventory, logout }, meta: { testVersion } } = uiTestCtx;
+    const { config, helpers: { login, clickApp, clickSettings, createInventory, logout } } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
     const servicePoint = 'Circ Desk 1';
@@ -20,12 +20,6 @@ module.exports.test = function uiTest(uiTestCtx) {
 
       after((done) => {
         logout(nightmare, config, done);
-      });
-
-      it('should open module "Requests" and find version tag ', (done) => {
-        nightmare
-          .use(openApp(nightmare, config, done, 'requests', testVersion))
-          .then(result => result);
       });
 
       let initialRules = '';


### PR DESCRIPTION
`helpers.openApp` uses the nav-bar to navigate between apps but we need
to use the app-menu in case the requested app has been pushed off the
bar.

Refs [UITEST-65](https://issues.folio.org/browse/UITEST-65)