### PR TITLE
clean up exercise test

### DIFF
--- a/test/ui-testing/exercise.js
+++ b/test/ui-testing/exercise.js
@@ -134,25 +134,23 @@ module.exports.test = (uiTestCtx) => {
       it(`should check out ${barcode}`, (done) => {
         nightmare
           .wait('#input-patron-identifier')
-          .type('#input-patron-identifier', userBarcode)
-          .wait(1000)
+          .insert('#input-patron-identifier', userBarcode)
           .wait('#clickable-find-patron')
           .click('#clickable-find-patron')
+          .wait('#clickable-done')
           .wait(() => {
             const err = document.querySelector('#patron-form div[class^="textfieldError"]');
-            const yay = document.querySelector('#patron-form ~ div a > strong');
+            // if (err) return false;
             if (err) {
               throw new Error(err.textContent);
-            } else if (yay) {
-              return true;
-            } else {
-              return false;
             }
+            return !!(document.querySelector('#patron-form ~ div a > strong'));
           })
           .wait('#input-item-barcode')
-          .type('#input-item-barcode', barcode)
+          .insert('#input-item-barcode', barcode)
           .wait('#clickable-add-item')
           .click('#clickable-add-item')
+          .wait('#list-items-checked-out')
           .wait(bc => {
             return !!(Array.from(document.querySelectorAll('#list-items-checked-out div[role="row"] div[role="gridcell"]'))
               .find(e => `${bc}` === e.textContent)); // `${}` forces string interpolation for numeric barcodes


### PR DESCRIPTION
The exercise test was failing after months of stability. I don't why it
started failing now, but here we are. The work was actually split over a
few PRs, folio-org/stripes-testing/pull/31 and a tiny tweak in
ui-inventory to relabel the new-holdings-button id to something more
sensical.

Here, I replaced `type` with `insert` for adding the user and item
barcodes because the input element was losing focus when the text was
only partially entered. I have no explanation for why this was the case,
but I saw it frequently during failed rounds of tests accompanied by a
warning that `<partial-barcode> could not be found.`