### PR TITLE
UITEST-67 correctly handle circulation rules

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -240,7 +240,12 @@ module.exports.test = (uiTestCtx) => {
 
           it('Apply the loan policy created as a circulation rule to material-type book', (done) => {
             const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} \nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName}`;
-            loanRules = helpers.setCirculationRules(nightmare, done, rules);
+            helpers.setCirculationRules(nightmare, rules)
+              .then(oldRules => {
+                loanRules = oldRules;
+              })
+              .then(done)
+              .catch(done);
           });
         });
 
@@ -584,7 +589,9 @@ module.exports.test = (uiTestCtx) => {
           });
 
           it('should restore the circulation rules', (done) => {
-            helpers.setCirculationRules(nightmare, done, loanRules);
+            helpers.setCirculationRules(nightmare, loanRules)
+              .then(() => done())
+              .catch(done);
           });
         });
 

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -30,7 +30,12 @@ module.exports.test = function uiTest(uiTestCtx) {
 
       it('should configure default circulation rules', (done) => {
         const newRules = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy \nm book: l example-loan-policy r allow-all n alternate-notice-policy';
-        initialRules = setCirculationRules(nightmare, done, newRules);
+        setCirculationRules(nightmare, newRules)
+          .then(oldRules => {
+            initialRules = oldRules;
+          })
+          .then(done)
+          .catch(done);
       });
 
       it('should navigate to users', (done) => {
@@ -154,7 +159,9 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       it('should restore initial circulation rules', (done) => {
-        setCirculationRules(nightmare, done, initialRules);
+        setCirculationRules(nightmare, initialRules)
+          .then(() => done())
+          .catch(done);
       });
     });
   });


### PR DESCRIPTION
Correctly use the setCirculationRules helper to get and restore
circulation rules reliably.

Refs [UITEST-67](https://issues.folio.org/browse/UITEST-67)