### PR TITLE
checkbox IDs use kebab-case

### DIFF
--- a/test/ui-testing/codex-search.js
+++ b/test/ui-testing/codex-search.js
@@ -43,8 +43,8 @@ module.exports.test = (uiTestCtx) => {
 
       it('should filter results and find 0 results', (done) => {
         nightmare
-          .wait('#clickable-filter-location-Annex')
-          .click('#clickable-filter-location-Annex')
+          .wait('#clickable-filter-location-annex')
+          .click('#clickable-filter-location-annex')
           .wait(() => {
             return !(document.querySelector('#list-search'));
           })
@@ -58,8 +58,8 @@ module.exports.test = (uiTestCtx) => {
       //
       it('should remove filter results and find results', (done) => {
         nightmare
-          .wait('#clickable-filter-location-Annex')
-          .click('#clickable-filter-location-Annex')
+          .wait('#clickable-filter-location-annex')
+          .click('#clickable-filter-location-annex')
           .wait('#list-search:not([data-total-count="0"])')
           .evaluate(() => {
             return document.querySelector('#list-search').getAttribute('data-total-count');


### PR DESCRIPTION
Prior to folio-org/stripes-smart-components/pull/583 checkbox IDs were
based on raw values which could contain spaces and other characters that
are illegal for HTML element IDs. Now those values are converted to
kebab-case first, and the tests must reflect that.