### PR TITLE
Merge monster

### DIFF
--- a/install.json
+++ b/install.json
@@ -1,29 +1,29 @@
 [ {
-  "id" : "mod-calendar-1.6.0",
+  "id" : "mod-calendar-1.6.1",
   "action" : "enable"
 }, {
-  "id" : "mod-inventory-storage-16.0.2",
+  "id" : "mod-inventory-storage-17.0.0",
   "action" : "enable"
 }, {
   "id" : "folio_calendar-2.4.0",
   "action" : "enable"
 }, {
-  "id" : "mod-circulation-storage-9.1.0",
+  "id" : "mod-circulation-storage-9.3.0",
   "action" : "enable"
 }, {
-  "id" : "mod-users-15.6.1",
+  "id" : "mod-users-15.6.2",
   "action" : "enable"
 }, {
-  "id" : "mod-event-config-1.3.1",
+  "id" : "mod-event-config-1.3.2",
   "action" : "enable"
 }, {
   "id" : "mod-configuration-5.1.0",
   "action" : "enable"
 }, {
-  "id" : "mod-template-engine-1.5.0",
+  "id" : "mod-template-engine-1.6.0",
   "action" : "enable"
 }, {
-  "id" : "mod-email-1.4.0",
+  "id" : "mod-email-1.5.0",
   "action" : "enable"
 }, {
   "id" : "mod-sender-1.1.0",
@@ -32,25 +32,28 @@
   "id" : "mod-notify-2.3.1",
   "action" : "enable"
 }, {
-  "id" : "mod-feesfines-15.5.0",
+  "id" : "mod-feesfines-15.6.0",
   "action" : "enable"
 }, {
-  "id" : "mod-circulation-16.5.1",
+  "id" : "mod-circulation-16.7.0",
   "action" : "enable"
 }, {
-  "id" : "folio_checkin-1.8.0",
+  "id" : "folio_checkin-1.9.0",
   "action" : "enable"
 }, {
   "id" : "folio_checkout-1.10.0",
   "action" : "enable"
 }, {
-  "id" : "folio_circulation-1.9.0",
+  "id" : "folio_circulation-1.11.0",
   "action" : "enable"
 }, {
   "id" : "folio_developer-1.10.0",
   "action" : "enable"
 }, {
-  "id" : "mod-inventory-12.0.0",
+  "id" : "mod-source-record-storage-2.6.0",
+  "action" : "enable"
+}, {
+  "id" : "mod-inventory-13.0.0",
   "action" : "enable"
 }, {
   "id" : "folio_inventory-1.11.1",
@@ -83,7 +86,7 @@
   "id" : "mod-login-6.0.0",
   "action" : "enable"
 }, {
-  "id" : "mod-password-validator-1.4.0",
+  "id" : "mod-password-validator-1.4.1",
   "action" : "enable"
 }, {
   "id" : "mod-authtoken-2.2.1",
@@ -92,16 +95,16 @@
   "id" : "mod-users-bl-5.0.0",
   "action" : "enable"
 }, {
-  "id" : "folio_stripes-core-3.8.0",
+  "id" : "folio_stripes-core-3.9.0",
   "action" : "enable"
 }, {
-  "id" : "mod-notes-2.6.1",
+  "id" : "mod-notes-2.7.0",
   "action" : "enable"
 }, {
   "id" : "mod-tags-0.4.0",
   "action" : "enable"
 }, {
-  "id" : "folio_stripes-smart-components-2.9.0",
+  "id" : "folio_stripes-smart-components-2.10.0",
   "action" : "enable"
 }, {
   "id" : "folio_tags-1.3.2",
@@ -110,10 +113,10 @@
   "id" : "mod-login-saml-1.2.2",
   "action" : "enable"
 }, {
-  "id" : "folio_tenant-settings-2.12.0",
+  "id" : "folio_tenant-settings-2.13.0",
   "action" : "enable"
 }, {
-  "id" : "folio_users-2.24.1",
+  "id" : "folio_users-2.25.1",
   "action" : "enable"
 }, {
   "id" : "mod-codex-inventory-1.5.0",

--- a/okapi-install.json
+++ b/okapi-install.json
@@ -1,22 +1,22 @@
 [
   {
-    "id": "mod-calendar-1.6.0",
+    "id": "mod-calendar-1.6.1",
     "action": "enable"
   },
   {
-    "id": "mod-inventory-storage-16.0.2",
+    "id": "mod-inventory-storage-17.0.0",
     "action": "enable"
   },
   {
-    "id": "mod-circulation-storage-9.1.0",
+    "id": "mod-circulation-storage-9.3.0",
     "action": "enable"
   },
   {
-    "id": "mod-users-15.6.1",
+    "id": "mod-users-15.6.2",
     "action": "enable"
   },
   {
-    "id": "mod-event-config-1.3.1",
+    "id": "mod-event-config-1.3.2",
     "action": "enable"
   },
   {
@@ -24,11 +24,11 @@
     "action": "enable"
   },
   {
-    "id": "mod-template-engine-1.5.0",
+    "id": "mod-template-engine-1.6.0",
     "action": "enable"
   },
   {
-    "id": "mod-email-1.4.0",
+    "id": "mod-email-1.5.0",
     "action": "enable"
   },
   {
@@ -40,15 +40,19 @@
     "action": "enable"
   },
   {
-    "id": "mod-feesfines-15.5.0",
+    "id": "mod-feesfines-15.6.0",
     "action": "enable"
   },
   {
-    "id": "mod-circulation-16.5.1",
+    "id": "mod-circulation-16.7.0",
     "action": "enable"
   },
   {
-    "id": "mod-inventory-12.0.0",
+    "id": "mod-source-record-storage-2.6.0",
+    "action": "enable"
+  },
+  {
+    "id": "mod-inventory-13.0.0",
     "action": "enable"
   },
   {
@@ -64,7 +68,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-password-validator-1.4.0",
+    "id": "mod-password-validator-1.4.1",
     "action": "enable"
   },
   {
@@ -76,7 +80,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-notes-2.6.1",
+    "id": "mod-notes-2.7.0",
     "action": "enable"
   },
   {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@folio/servicepoints": "1.4.0",
     "@folio/stripes": "2.10.1",
     "@folio/tags": "1.3.2",
-    "@folio/tenant-settings": "2.12.0",
+    "@folio/tenant-settings": "2.13.0",
     "@folio/users": "2.25.1",
     "react": "~16.8.6",
     "react-dom": "~16.8.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@folio/requests": "1.11.0",
     "@folio/search": "1.8.0",
     "@folio/servicepoints": "1.4.0",
-    "@folio/stripes": "2.9.0",
+    "@folio/stripes": "2.10.1",
     "@folio/tags": "1.3.2",
     "@folio/tenant-settings": "2.12.0",
     "@folio/users": "2.24.1",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     "@folio/calendar": "2.4.0",
-    "@folio/checkin": "1.8.0",
+    "@folio/checkin": "1.9.0",
     "@folio/checkout": "1.10.0",
-    "@folio/circulation": "1.9.0",
+    "@folio/circulation": "1.11.0",
     "@folio/developer": "1.10.0",
     "@folio/inventory": "1.11.1",
     "@folio/myprofile": "1.7.0",
@@ -34,8 +34,8 @@
     "@folio/tags": "1.3.2",
     "@folio/tenant-settings": "2.12.0",
     "@folio/users": "2.25.1",
-    "react": "~16.6.3",
-    "react-dom": "~16.6.3",
+    "react": "~16.8.6",
+    "react-dom": "~16.8.6",
     "react-redux": "~5.1.1",
     "redux": "~3.7.2"
   },

--- a/stripes-install.json
+++ b/stripes-install.json
@@ -4,7 +4,7 @@
     "action": "enable"
   },
   {
-    "id": "folio_checkin-1.8.0",
+    "id": "folio_checkin-1.9.0",
     "action": "enable"
   },
   {
@@ -12,7 +12,7 @@
     "action": "enable"
   },
   {
-    "id": "folio_circulation-1.9.0",
+    "id": "folio_circulation-1.11.0",
     "action": "enable"
   },
   {
@@ -48,11 +48,11 @@
     "action": "enable"
   },
   {
-    "id": "folio_stripes-core-3.8.0",
+    "id": "folio_stripes-core-3.9.0",
     "action": "enable"
   },
   {
-    "id": "folio_stripes-smart-components-2.9.0",
+    "id": "folio_stripes-smart-components-2.10.0",
     "action": "enable"
   },
   {
@@ -60,11 +60,11 @@
     "action": "enable"
   },
   {
-    "id": "folio_tenant-settings-2.12.0",
+    "id": "folio_tenant-settings-2.13.0",
     "action": "enable"
   },
   {
-    "id": "folio_users-2.24.1",
+    "id": "folio_users-2.25.1",
     "action": "enable"
   },
   {

--- a/test/ui-testing/codex-search.js
+++ b/test/ui-testing/codex-search.js
@@ -43,8 +43,8 @@ module.exports.test = (uiTestCtx) => {
 
       it('should filter results and find 0 results', (done) => {
         nightmare
-          .wait('#location input[type="checkbox"][name="Annex"]')
-          .click('#location input[type="checkbox"][name="Annex"]')
+          .wait('#clickable-filter-location-annex')
+          .click('#clickable-filter-location-annex')
           .wait(() => {
             return !(document.querySelector('#list-search'));
           })
@@ -58,8 +58,8 @@ module.exports.test = (uiTestCtx) => {
       //
       it('should remove filter results and find results', (done) => {
         nightmare
-          .wait('#location input[type="checkbox"][name="Annex"]')
-          .click('#location input[type="checkbox"][name="Annex"]')
+          .wait('#clickable-filter-location-annex')
+          .click('#clickable-filter-location-annex')
           .wait('#list-search:not([data-total-count="0"])')
           .evaluate(() => {
             return document.querySelector('#list-search').getAttribute('data-total-count');

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -43,11 +43,11 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       it('should find an active user barcode for checkout', (done) => {
-        const listitem = '#list-users div[role="row"]:nth-of-type(2) > a div:nth-child(3)';
+        const listitem = '#list-users [aria-rowindex="4"] [role=gridcell]:nth-of-type(3)';
         nightmare
           .wait('#clickable-filter-active-active')
           .click('#clickable-filter-active-active')
-          .wait('#list-users:not([data-total-count="0"])')
+          .wait('#list-users[data-total-count]')
           .evaluate(() => {
             return document.querySelector('#list-users').getAttribute('data-total-count');
           })
@@ -71,7 +71,7 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       it('should find an active user barcode for request', (done) => {
-        const listitem = '#list-users div[role="row"]:nth-of-type(3) > a div:nth-child(3)';
+        const listitem = '#list-users [aria-rowIndex="5"] [role=gridcell]:nth-of-type(3)';
         nightmare
           .evaluate((bcode) => {
             return document.querySelector(bcode).textContent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,16 +15,16 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.4.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/core/-/core-7.6.0.tgz#9b00f73554edd67bebc86df8303ef678be3d7b48"
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.5.5"
-    "@babel/helpers" "^7.5.5"
-    "@babel/parser" "^7.5.5"
-    "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.5.5"
-    "@babel/types" "^7.5.5"
+    "@babel/generator" "^7.6.0"
+    "@babel/helpers" "^7.6.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
     json5 "^2.1.0"
@@ -43,11 +43,11 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.5.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
+"@babel/generator@^7.4.0", "@babel/generator@^7.6.0":
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/generator/-/generator-7.6.0.tgz#e2c21efbfd3293ad819a2359b448f002bfdfda56"
   dependencies:
-    "@babel/types" "^7.5.5"
+    "@babel/types" "^7.6.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -110,13 +110,13 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
-"@babel/helpers@^7.5.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/helpers/-/helpers-7.5.5.tgz#63908d2a73942229d1e6685bc2a0e730dde3b75e"
+"@babel/helpers@^7.6.0":
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/helpers/-/helpers-7.6.0.tgz#21961d16c6a3c3ab597325c34c465c0887d31c6e"
   dependencies:
-    "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.5.5"
-    "@babel/types" "^7.5.5"
+    "@babel/template" "^7.6.0"
+    "@babel/traverse" "^7.6.0"
+    "@babel/types" "^7.6.0"
 
 "@babel/highlight@7.0.0-beta.51":
   version "7.0.0-beta.51"
@@ -138,9 +138,9 @@
   version "7.0.0-beta.51"
   resolved "https://repository.folio.org/repository/npm-ci-all/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
 
-"@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.5.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
+"@babel/parser@^7.4.3", "@babel/parser@^7.6.0":
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
 
 "@babel/plugin-syntax-jsx@^7.2.0":
   version "7.2.0"
@@ -177,8 +177,8 @@
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
 "@babel/polyfill@^7.0.0":
-  version "7.4.4"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/polyfill/-/polyfill-7.6.0.tgz#6d89203f8b6cd323e8d946e47774ea35dc0619cc"
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
@@ -194,15 +194,15 @@
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
 "@babel/runtime-corejs2@^7.0.0":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz#c3214c08ef20341af4187f1c9fbdc357fbec96b2"
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/runtime-corejs2/-/runtime-corejs2-7.6.0.tgz#6fcd37c2580070817d62f219db97f67e26f50f9c"
   dependencies:
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5":
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -215,13 +215,13 @@
     "@babel/types" "7.0.0-beta.51"
     lodash "^4.17.5"
 
-"@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
-  version "7.4.4"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
+"@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.6.0":
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.4.4"
-    "@babel/types" "^7.4.4"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
 
 "@babel/traverse@7.0.0-beta.51":
   version "7.0.0-beta.51"
@@ -238,16 +238,16 @@
     invariant "^2.2.0"
     lodash "^4.17.5"
 
-"@babel/traverse@^7.4.3", "@babel/traverse@^7.5.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
+"@babel/traverse@^7.4.3", "@babel/traverse@^7.6.0":
+  version "7.6.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
   dependencies:
     "@babel/code-frame" "^7.5.5"
-    "@babel/generator" "^7.5.5"
+    "@babel/generator" "^7.6.0"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.5.5"
-    "@babel/types" "^7.5.5"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
@@ -260,9 +260,9 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5":
-  version "7.5.5"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0":
+  version "7.6.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.13"
@@ -285,9 +285,9 @@
     redux-form "^7.0.3"
     style-loader "^0.21.0"
 
-"@folio/checkin@1.8.0":
-  version "1.8.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/checkin/-/checkin-1.8.0.tgz#afd96894e42d6d1aa58c38c1188699f49146de14"
+"@folio/checkin@1.9.0":
+  version "1.9.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/checkin/-/checkin-1.9.0.tgz#864a3b71c25f929406d147bb827423364936146d"
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.0"
     dateformat "^2.0.0"
@@ -299,7 +299,7 @@
     react-hot-loader "^4.3.12"
     react-intl "^2.4.0"
     react-router-dom "^4.0.0"
-    react-to-print "^1.0.21"
+    react-to-print "^2.3.2"
     redux-form "^7.0.3"
 
 "@folio/checkout@1.10.0":
@@ -319,9 +319,9 @@
   optionalDependencies:
     "@folio/plugin-find-user" "^1.1.0"
 
-"@folio/circulation@1.9.0":
-  version "1.9.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/circulation/-/circulation-1.9.0.tgz#f0001c32569660ac38c8512e60b6e195e02c4838"
+"@folio/circulation@1.11.0":
+  version "1.11.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/circulation/-/circulation-1.11.0.tgz#657cc4fb2d4f258d42a118ccbe93d45775cc0b68"
   dependencies:
     html-to-react "^1.3.3"
     isomorphic-fetch "^2.2.1"
@@ -332,7 +332,7 @@
     react-codemirror2 "^1.0.0"
     react-intl "^2.4.0"
     react-quill "^1.2.7"
-    react-to-print "^1.0.21"
+    react-to-print "^2.3.2"
     redux-form "^7.0.3"
 
 "@folio/developer@1.10.0":
@@ -359,7 +359,7 @@
     eslint-plugin-react "7.11.0"
     webpack "^4.0.0"
 
-"@folio/inventory@1.11.1", "@folio/inventory@^1.4.0":
+"@folio/inventory@1.11.1":
   version "1.11.1"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/inventory/-/inventory-1.11.1.tgz#3ed2bfa56c56af5d1ceebcbe5f6b612ae5ef9701"
   dependencies:
@@ -372,6 +372,25 @@
     react-router "^4.0.0"
     react-router-dom "^4.0.0"
     redux-form "^7.0.3"
+
+"@folio/inventory@^1.4.0":
+  version "1.12.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/inventory/-/inventory-1.12.0.tgz#1de1657df154986bebaa7539fc3fe81f19c32cc5"
+  dependencies:
+    "@folio/react-intl-safe-html" "^1.0.2"
+    final-form "^4.18.2"
+    final-form-arrays "^3.0.1"
+    lodash "^4.17.4"
+    prop-types "^15.5.10"
+    query-string "^5.0.0"
+    react-copy-to-clipboard "^5.0.1"
+    react-final-form "^6.3.0"
+    react-final-form-arrays "^3.1.0"
+    react-final-form-listeners "^1.0.2"
+    react-hot-loader "^4.3.12"
+    react-intl "^2.3.0"
+    react-router "^4.0.0"
+    react-router-dom "^4.0.0"
 
 "@folio/myprofile@1.7.0":
   version "1.7.0"
@@ -391,9 +410,18 @@
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-"@folio/plugin-find-user@1.8.0", "@folio/plugin-find-user@^1.1.0":
+"@folio/plugin-find-user@1.8.0":
   version "1.8.0"
   resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-user/-/plugin-find-user-1.8.0.tgz#16ce7cca2fbaa5bc5f17a0576e02269d4febac19"
+  dependencies:
+    classnames "^2.2.5"
+    dom-helpers "^3.4.0"
+    lodash "^4.17.4"
+    prop-types "^15.6.0"
+
+"@folio/plugin-find-user@^1.1.0":
+  version "1.9.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/plugin-find-user/-/plugin-find-user-1.9.0.tgz#ce741d4698615cb605ee9003100bfea0652d5fe9"
   dependencies:
     classnames "^2.2.5"
     dom-helpers "^3.4.0"
@@ -461,8 +489,8 @@
     react-router-dom "^4.1.1"
 
 "@folio/stripes-cli@^1.12.0":
-  version "1.13.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-cli/-/stripes-cli-1.13.0.tgz#99f8b77e81c72535e96623c7bd8b6ecaf7eacc13"
+  version "1.14.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-cli/-/stripes-cli-1.14.0.tgz#4a6cff5c3047724162936d0a032cd915c48f9883"
   dependencies:
     "@folio/stripes-core" "^2.17.1 || ^3.0.0"
     "@folio/stripes-testing" "^1.6.0"
@@ -471,6 +499,7 @@
     debug "^4.0.1"
     fast-xml-parser "^3.12.10"
     find-up "^2.1.0"
+    fs-extra "^8.1.0"
     get-stdin "^6.0.0"
     global-dirs "^0.1.1"
     http-server "^0.11.1"
@@ -478,6 +507,7 @@
     inquirer "^6.3.1"
     is-installed-globally "^0.1.0"
     is-path-inside "^1.0.1"
+    istanbul-reports "^2.2.6"
     just-kebab-case "^1.0.0"
     just-pascal-case "^1.0.0"
     karma "^3.0.0"
@@ -506,9 +536,9 @@
     webpack-bundle-analyzer "^3.3.2"
     yargs "^13.1.0"
 
-"@folio/stripes-components@~5.6.0":
-  version "5.6.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-5.6.0.tgz#f7d7eba38caefc11f13a95d6b4dabbbee636a049"
+"@folio/stripes-components@~5.7.0", "@folio/stripes-components@~5.7.1":
+  version "5.7.1"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-components/-/stripes-components-5.7.1.tgz#e5facd437701834c72a82172fed65b3ca1bcb941"
   dependencies:
     "@folio/stripes-react-hotkeys" "^2.0.0"
     classnames "^2.2.5"
@@ -539,9 +569,9 @@
     react-virtualized-auto-sizer "^1.0.2"
     tai-password-strength "^1.1.1"
 
-"@folio/stripes-connect@~5.3.0":
-  version "5.3.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-5.3.0.tgz#740c9d58e4aed57eb590e834307d960e539761e5"
+"@folio/stripes-connect@~5.4.0":
+  version "5.4.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-connect/-/stripes-connect-5.4.0.tgz#fa9a5578d35275207f5de9829269c8517ace0d7b"
   dependencies:
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.11"
@@ -551,13 +581,13 @@
     redux "^3.6.0"
     uuid "^3.0.1"
 
-"@folio/stripes-core@^2.17.1 || ^3.0.0", "@folio/stripes-core@~3.8.0":
-  version "3.8.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-core/-/stripes-core-3.8.0.tgz#d4fb9e69fe309d663b65551d9cc226cc22fe0d05"
+"@folio/stripes-core@^2.17.1 || ^3.0.0", "@folio/stripes-core@~3.9.0":
+  version "3.9.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-core/-/stripes-core-3.9.0.tgz#7a1d35d5f7932f83e943bef1277083c8a238b931"
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.2"
-    "@folio/stripes-components" "~5.6.0"
-    "@folio/stripes-connect" "~5.3.0"
+    "@folio/stripes-components" "~5.7.0"
+    "@folio/stripes-connect" "~5.4.0"
     "@folio/stripes-logger" "~1.0.0"
     apollo-cache-inmemory "^1.1.1"
     apollo-client "^2.0.3"
@@ -641,12 +671,12 @@
     webpack-hot-middleware "^2.22.2"
     webpack-virtual-modules "^0.1.10"
 
-"@folio/stripes-final-form@~1.1.0":
-  version "1.1.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-final-form/-/stripes-final-form-1.1.0.tgz#a55028a7c7359e0b4f60df5d2d5a140002d74bbb"
+"@folio/stripes-final-form@~1.2.0":
+  version "1.2.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-final-form/-/stripes-final-form-1.2.0.tgz#c4bc1741c152799a9da9ef81dee13c69fdc385e5"
   dependencies:
-    "@folio/stripes-components" "~5.6.0"
-    "@folio/stripes-core" "~3.8.0"
+    "@folio/stripes-components" "~5.7.0"
+    "@folio/stripes-core" "~3.9.0"
     final-form "^4.18.2"
     final-form-arrays "^3.0.1"
     final-form-focus "^1.1.2"
@@ -657,12 +687,12 @@
     react-intl "^2.4.0"
     react-router "^4.1.1"
 
-"@folio/stripes-form@~2.8.0":
-  version "2.8.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-2.8.0.tgz#c5992b9db7ab120776b60120a81d2a17aa98130d"
+"@folio/stripes-form@~2.9.0":
+  version "2.9.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-form/-/stripes-form-2.9.0.tgz#c91520e027bbc8b0a2adf4cb2c1353b9569d7f12"
   dependencies:
-    "@folio/stripes-components" "~5.6.0"
-    "@folio/stripes-core" "~3.8.0"
+    "@folio/stripes-components" "~5.7.0"
+    "@folio/stripes-core" "~3.9.0"
     flat "^4.0.0"
     prop-types "^15.5.10"
     react-intl "^2.4.0"
@@ -682,15 +712,15 @@
     mousetrap "^1.6.1"
     prop-types "^15.5.10"
 
-"@folio/stripes-smart-components@~2.9.0":
-  version "2.9.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-smart-components/-/stripes-smart-components-2.9.0.tgz#ac3e94e55f29ecf9a6270b502b693a28e31432ad"
+"@folio/stripes-smart-components@~2.10.0":
+  version "2.10.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-smart-components/-/stripes-smart-components-2.10.0.tgz#4168553b410711aa7e22028cdc642686fd32abe1"
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.2"
-    "@folio/stripes-components" "~5.6.0"
-    "@folio/stripes-connect" "~5.3.0"
-    "@folio/stripes-core" "~3.8.0"
-    "@folio/stripes-form" "~2.8.0"
+    "@folio/stripes-components" "~5.7.0"
+    "@folio/stripes-connect" "~5.4.0"
+    "@folio/stripes-core" "~3.9.0"
+    "@folio/stripes-form" "~2.9.0"
     "@folio/stripes-logger" "~1.0.0"
     classnames "^2.2.6"
     final-form "^4.18.2"
@@ -709,8 +739,8 @@
     redux-form "^7.0.3"
 
 "@folio/stripes-testing@^1.6.0":
-  version "1.6.1"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-testing/-/stripes-testing-1.6.1.tgz#83a6441bad156b32d51a88446f11d5918872f292"
+  version "1.6.6"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes-testing/-/stripes-testing-1.6.6.tgz#2786e909eb1eeb64c16537f50ae079687901a308"
   dependencies:
     debug "^4.0.1"
     minimist "^1.2.0"
@@ -725,17 +755,17 @@
     query-string "^5.0.0"
     react-intl "^2.4.0"
 
-"@folio/stripes@2.9.0":
-  version "2.9.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes/-/stripes-2.9.0.tgz#a2464d8c904845eee3a454402914cafde2144a78"
+"@folio/stripes@2.10.1":
+  version "2.10.1"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/stripes/-/stripes-2.10.1.tgz#7bc462b74c5f567efad24d600d1c36e5fad1f8b7"
   dependencies:
-    "@folio/stripes-components" "~5.6.0"
-    "@folio/stripes-connect" "~5.3.0"
-    "@folio/stripes-core" "~3.8.0"
-    "@folio/stripes-final-form" "~1.1.0"
-    "@folio/stripes-form" "~2.8.0"
+    "@folio/stripes-components" "~5.7.1"
+    "@folio/stripes-connect" "~5.4.0"
+    "@folio/stripes-core" "~3.9.0"
+    "@folio/stripes-final-form" "~1.2.0"
+    "@folio/stripes-form" "~2.9.0"
     "@folio/stripes-logger" "~1.0.0"
-    "@folio/stripes-smart-components" "~2.9.0"
+    "@folio/stripes-smart-components" "~2.10.0"
     "@folio/stripes-util" "~1.5.0"
     react "~16.8.6"
     react-dom "~16.8.6"
@@ -750,9 +780,9 @@
     react-intl "^2.7.2"
     redux-form "^7.0.3"
 
-"@folio/tenant-settings@2.12.0":
-  version "2.12.0"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/tenant-settings/-/tenant-settings-2.12.0.tgz#1c1a0ad0e7d966d68822aecffa077b35fb568397"
+"@folio/tenant-settings@2.13.0":
+  version "2.13.0"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/tenant-settings/-/tenant-settings-2.13.0.tgz#5c1e37ca92909d10f839862a43bd6ffe1686f81b"
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.1"
     lodash "^4.17.4"
@@ -762,9 +792,9 @@
     react-router-dom "^4.1.1"
     redux-form "^7.0.3"
 
-"@folio/users@2.24.1":
-  version "2.24.1"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/users/-/users-2.24.1.tgz#1dab94cdd16cfa1dd521b3c7c95eec75d60c6aff"
+"@folio/users@2.25.1":
+  version "2.25.1"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/users/-/users-2.25.1.tgz#91c74241610a51f8cf2dd4438f187cb2b32a8f73"
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.0"
     hashcode "^1.0.3"
@@ -775,6 +805,7 @@
     react-hot-loader "^4.3.12"
     react-intl "^2.5.0"
     react-router-dom "^4.0.0"
+    react-router-prop-types "^1.0.4"
     redux-form "^7.0.3"
     uuid "^3.0.1"
   optionalDependencies:
@@ -1006,12 +1037,12 @@
     core-js "^2.5.7"
 
 "@types/node@>=6":
-  version "12.7.4"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@types/node/-/node-12.7.4.tgz#64db61e0359eb5a8d99b55e05c729f130a678b04"
+  version "12.7.5"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@types/node/-/node-12.7.5.tgz#e19436e7f8e9b4601005d73673b6dc4784ffcc2f"
 
 "@types/node@^8.0.24":
-  version "8.10.53"
-  resolved "https://repository.folio.org/repository/npm-ci-all/@types/node/-/node-8.10.53.tgz#5fa08eef810b08b2c03073e360b54f7bad899db1"
+  version "8.10.54"
+  resolved "https://repository.folio.org/repository/npm-ci-all/@types/node/-/node-8.10.54.tgz#1c88eb253ac1210f1a5876953fb70f7cc4928402"
 
 "@types/prop-types@*", "@types/prop-types@^15.5.3":
   version "15.7.2"
@@ -1330,30 +1361,30 @@ apollo-client@^2.0.3:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-apollo-link-http-common@^0.2.14:
-  version "0.2.14"
-  resolved "https://repository.folio.org/repository/npm-ci-all/apollo-link-http-common/-/apollo-link-http-common-0.2.14.tgz#d3a195c12e00f4e311c417f121181dcc31f7d0c8"
+apollo-link-http-common@^0.2.15:
+  version "0.2.15"
+  resolved "https://repository.folio.org/repository/npm-ci-all/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz#304e67705122bf69a9abaded4351b10bc5efd6d9"
   dependencies:
-    apollo-link "^1.2.12"
+    apollo-link "^1.2.13"
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
 apollo-link-http@^1.2.0:
-  version "1.5.15"
-  resolved "https://repository.folio.org/repository/npm-ci-all/apollo-link-http/-/apollo-link-http-1.5.15.tgz#106ab23bb8997bd55965d05855736d33119652cf"
+  version "1.5.16"
+  resolved "https://repository.folio.org/repository/npm-ci-all/apollo-link-http/-/apollo-link-http-1.5.16.tgz#44fe760bcc2803b8a7f57fc9269173afb00f3814"
   dependencies:
-    apollo-link "^1.2.12"
-    apollo-link-http-common "^0.2.14"
+    apollo-link "^1.2.13"
+    apollo-link-http-common "^0.2.15"
     tslib "^1.9.3"
 
-apollo-link@^1.0.0, apollo-link@^1.2.12:
-  version "1.2.12"
-  resolved "https://repository.folio.org/repository/npm-ci-all/apollo-link/-/apollo-link-1.2.12.tgz#014b514fba95f1945c38ad4c216f31bcfee68429"
+apollo-link@^1.0.0, apollo-link@^1.2.13:
+  version "1.2.13"
+  resolved "https://repository.folio.org/repository/npm-ci-all/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
   dependencies:
     apollo-utilities "^1.3.0"
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
-    zen-observable-ts "^0.8.19"
+    zen-observable-ts "^0.8.20"
 
 apollo-utilities@1.3.2, apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
   version "1.3.2"
@@ -2350,12 +2381,11 @@ binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://repository.folio.org/repository/npm-ci-all/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
 
-bl@^1.0.0:
-  version "1.2.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
+bl@^3.0.0:
+  version "3.0.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/bl/-/bl-3.0.0.tgz#3611ec00579fd18561754360b21e9f784500ff88"
   dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
+    readable-stream "^3.0.1"
 
 blacklist@^1.1.4:
   version "1.1.4"
@@ -2583,8 +2613,8 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.2.0:
-  version "5.4.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/buffer/-/buffer-5.4.2.tgz#2012872776206182480eccb2c0fba5f672a2efef"
+  version "5.4.3"
+  resolved "https://repository.folio.org/repository/npm-ci-all/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -2781,7 +2811,7 @@ chokidar@^2.0.2, chokidar@^2.0.3:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chownr@^1.0.1, chownr@^1.1.1:
+chownr@^1.1.1:
   version "1.1.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/chownr/-/chownr-1.1.2.tgz#a18f1e0b269c8a6a5d3c86eb298beb14c3dd7bf6"
 
@@ -3124,6 +3154,12 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
+copy-to-clipboard@^3:
+  version "3.2.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://repository.folio.org/repository/npm-ci-all/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -3430,9 +3466,9 @@ custom-event@~1.0.0:
   version "1.0.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/custom-event/-/custom-event-1.0.1.tgz#5d02a46850adf1b4a317946a3928fccb5bfd0425"
 
-cyclist@~0.2.2:
-  version "0.2.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+cyclist@^1.0.1:
+  version "1.0.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
 
 d@1, d@^1.0.1:
   version "1.0.1"
@@ -3503,11 +3539,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://repository.folio.org/repository/npm-ci-all/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
-decompress-response@^3.3.0:
-  version "3.3.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+decompress-response@^4.2.0:
+  version "4.2.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/decompress-response/-/decompress-response-4.2.1.tgz#414023cc7a302da25ce2ec82d0d5238ccafd8986"
   dependencies:
-    mimic-response "^1.0.0"
+    mimic-response "^2.0.0"
 
 deep-defaults@^1.0.3:
   version "1.0.5"
@@ -3835,8 +3871,8 @@ electron-download@^3.0.1:
     sumchecker "^1.2.0"
 
 electron-to-chromium@^1.3.247, electron-to-chromium@^1.3.47:
-  version "1.3.252"
-  resolved "https://repository.folio.org/repository/npm-ci-all/electron-to-chromium/-/electron-to-chromium-1.3.252.tgz#5b6261965b564a0f4df0f1c86246487897017f52"
+  version "1.3.262"
+  resolved "https://repository.folio.org/repository/npm-ci-all/electron-to-chromium/-/electron-to-chromium-1.3.262.tgz#8022933e46e5a2c7b0fd1565d215872326520a7c"
 
 electron@^2.0.18:
   version "2.0.18"
@@ -3880,7 +3916,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
   dependencies:
@@ -3976,8 +4012,8 @@ error-stack-parser@^1.3.6:
     stackframe "^0.3.1"
 
 es-abstract@^1.12.0, es-abstract@^1.13.0, es-abstract@^1.5.1, es-abstract@^1.7.0:
-  version "1.14.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/es-abstract/-/es-abstract-1.14.1.tgz#6e8d84b445ec9c610781e74a6d52cc31aac5b4ca"
+  version "1.14.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/es-abstract/-/es-abstract-1.14.2.tgz#7ce108fad83068c8783c3cdf62e504e084d8c497"
   dependencies:
     es-to-primitive "^1.2.0"
     function-bind "^1.1.1"
@@ -4254,9 +4290,9 @@ eventemitter3@^2.0.3:
   version "2.0.3"
   resolved "https://repository.folio.org/repository/npm-ci-all/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
 
-eventemitter3@^3.0.0:
-  version "3.1.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+eventemitter3@^4.0.0:
+  version "4.0.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
 
 events@^3.0.0:
   version "3.0.0"
@@ -4376,7 +4412,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@^3.0.1, extend@^3.0.2, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -4672,8 +4708,8 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0:
-  version "1.8.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/follow-redirects/-/follow-redirects-1.8.1.tgz#24804f9eaab67160b0e840c085885d606371a35b"
+  version "1.9.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/follow-redirects/-/follow-redirects-1.9.0.tgz#8d5bcdc65b7108fe1508649c79c12d732dcedb4f"
   dependencies:
     debug "^3.0.0"
 
@@ -4769,11 +4805,19 @@ fs-extra@^3.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.6"
-  resolved "https://repository.folio.org/repository/npm-ci-all/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   dependencies:
-    minipass "^2.2.1"
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-minipass@^1.2.5:
+  version "1.2.7"
+  resolved "https://repository.folio.org/repository/npm-ci-all/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  dependencies:
+    minipass "^2.6.0"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -4795,7 +4839,7 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -4957,7 +5001,7 @@ got@^6.7.1:
     unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
   version "4.2.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
 
@@ -5119,15 +5163,15 @@ hex-color-regex@^1.1.0:
   resolved "https://repository.folio.org/repository/npm-ci-all/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
 
 history@^4.6.3, history@^4.7.2:
-  version "4.9.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/history/-/history-4.9.0.tgz#84587c2068039ead8af769e9d6a6860a14fa1bca"
+  version "4.10.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
   dependencies:
     "@babel/runtime" "^7.1.2"
     loose-envify "^1.2.0"
-    resolve-pathname "^2.2.0"
+    resolve-pathname "^3.0.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
-    value-equal "^0.4.0"
+    value-equal "^1.0.1"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -5155,8 +5199,8 @@ home-or-tmp@^2.0.0:
     os-tmpdir "^1.0.1"
 
 home-path@^1.0.1:
-  version "1.0.6"
-  resolved "https://repository.folio.org/repository/npm-ci-all/home-path/-/home-path-1.0.6.tgz#d549dc2465388a7f8667242c5b31588d29af29fc"
+  version "1.0.7"
+  resolved "https://repository.folio.org/repository/npm-ci-all/home-path/-/home-path-1.0.7.tgz#cf77d7339ff3ddc3347a23c52612b1f5e7e56313"
 
 hoopy@^0.1.4:
   version "0.1.4"
@@ -5256,10 +5300,10 @@ http-errors@~1.7.2:
     toidentifier "1.0.0"
 
 http-proxy@^1.13.0, http-proxy@^1.8.1:
-  version "1.17.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/http-proxy/-/http-proxy-1.17.0.tgz#7ad38494658f84605e2f6db4436df410f4e5be9a"
+  version "1.18.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
   dependencies:
-    eventemitter3 "^3.0.0"
+    eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
 
@@ -5320,8 +5364,8 @@ iferr@^0.1.5:
   resolved "https://repository.folio.org/repository/npm-ci-all/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
 
 ignore-walk@^3.0.1:
-  version "3.0.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/ignore-walk/-/ignore-walk-3.0.1.tgz#a83e62e7d272ac0e3b551aaa82831a19b69f82f8"
+  version "3.0.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/ignore-walk/-/ignore-walk-3.0.2.tgz#99d83a246c196ea5c93ef9315ad7b0819c35069b"
   dependencies:
     minimatch "^3.0.4"
 
@@ -5334,8 +5378,8 @@ image-size@^0.5.0:
   resolved "https://repository.folio.org/repository/npm-ci-all/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
 
 image-size@^0.7.4:
-  version "0.7.4"
-  resolved "https://repository.folio.org/repository/npm-ci-all/image-size/-/image-size-0.7.4.tgz#092c1e541a93511917bfc957a1fc7add21c72e87"
+  version "0.7.5"
+  resolved "https://repository.folio.org/repository/npm-ci-all/image-size/-/image-size-0.7.5.tgz#269f357cf5797cb44683dfa99790e54c705ead04"
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -5758,8 +5802,8 @@ is-resolvable@^1.0.0:
   resolved "https://repository.folio.org/repository/npm-ci-all/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
 is-retry-allowed@^1.0.0:
-  version "1.1.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+  version "1.2.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
 
 is-running@^2.0.0:
   version "2.1.0"
@@ -5961,7 +6005,7 @@ istanbul-reports@^1.4.1:
   dependencies:
     handlebars "^4.0.3"
 
-istanbul-reports@^2.2.4:
+istanbul-reports@^2.2.4, istanbul-reports@^2.2.6:
   version "2.2.6"
   resolved "https://repository.folio.org/repository/npm-ci-all/istanbul-reports/-/istanbul-reports-2.2.6.tgz#7b4f2660d82b29303a8fe6091f8ca4bf058da1af"
   dependencies:
@@ -6070,8 +6114,8 @@ json-stringify-safe@~5.0.1:
   resolved "https://repository.folio.org/repository/npm-ci-all/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
 json2csv@^4.2.1:
-  version "4.5.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/json2csv/-/json2csv-4.5.2.tgz#75f0808cb89ed8ef7e338445a510a3cd3e385dfe"
+  version "4.5.3"
+  resolved "https://repository.folio.org/repository/npm-ci-all/json2csv/-/json2csv-4.5.3.tgz#74cdde618929317261dfe2b97677a5e891bdc263"
   dependencies:
     commander "^2.15.1"
     jsonparse "^1.3.1"
@@ -6102,6 +6146,12 @@ jsonfile@^2.1.0:
 jsonfile@^3.0.0:
   version "3.0.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -6711,9 +6761,9 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://repository.folio.org/repository/npm-ci-all/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-mimic-response@^1.0.0:
-  version "1.0.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
+mimic-response@^2.0.0:
+  version "2.0.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/mimic-response/-/mimic-response-2.0.0.tgz#996a51c60adf12cb8a87d7fb8ef24c2f3d5ebb46"
 
 min-document@^2.19.0:
   version "2.19.0"
@@ -6755,16 +6805,16 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://repository.folio.org/repository/npm-ci-all/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1, minipass@^2.3.5:
-  version "2.5.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/minipass/-/minipass-2.5.0.tgz#dddb1d001976978158a05badfcbef4a771612857"
+minipass@^2.2.1, minipass@^2.6.0, minipass@^2.6.4:
+  version "2.6.5"
+  resolved "https://repository.folio.org/repository/npm-ci-all/minipass/-/minipass-2.6.5.tgz#1c245f9f2897f70fd4a219066261ce6c29f80b18"
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
 minizlib@^1.2.1:
-  version "1.2.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
+  version "1.2.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/minizlib/-/minizlib-1.2.2.tgz#6f0ccc82fa53e1bf2ff145f220d2da9fa6e3a166"
   dependencies:
     minipass "^2.2.1"
 
@@ -7050,8 +7100,8 @@ node-pre-gyp@^0.12.0:
     tar "^4"
 
 node-releases@^1.1.29:
-  version "1.1.29"
-  resolved "https://repository.folio.org/repository/npm-ci-all/node-releases/-/node-releases-1.1.29.tgz#86a57c6587a30ecd6726449e5d293466b0a0bb86"
+  version "1.1.32"
+  resolved "https://repository.folio.org/repository/npm-ci-all/node-releases/-/node-releases-1.1.32.tgz#485b35c1bf9b4d8baa105d782f8ca731e518276e"
   dependencies:
     semver "^5.3.0"
 
@@ -7316,8 +7366,8 @@ opener@~1.4.0:
   resolved "https://repository.folio.org/repository/npm-ci-all/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
 
 optimism@^0.10.0:
-  version "0.10.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/optimism/-/optimism-0.10.2.tgz#626b6fd28b0923de98ecb36a3fd2d3d4e5632dd9"
+  version "0.10.3"
+  resolved "https://repository.folio.org/repository/npm-ci-all/optimism/-/optimism-0.10.3.tgz#163268fdc741dea2fb50f300bedda80356445fd7"
   dependencies:
     "@wry/context" "^0.4.0"
 
@@ -7423,10 +7473,10 @@ pako@^1.0.5, pako@~1.0.5:
   resolved "https://repository.folio.org/repository/npm-ci-all/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
 
 parallel-transform@^1.1.0:
-  version "1.1.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"
+  version "1.2.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/parallel-transform/-/parallel-transform-1.2.0.tgz#9049ca37d6cb2182c3b1d2c720be94d14a5814fc"
   dependencies:
-    cyclist "~0.2.2"
+    cyclist "^1.0.1"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
@@ -7447,8 +7497,8 @@ parent-module@^1.0.0:
     callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
-  version "5.1.4"
-  resolved "https://repository.folio.org/repository/npm-ci-all/parse-asn1/-/parse-asn1-5.1.4.tgz#37f6628f823fbdeb2273b4d540434a22f3ef1fcc"
+  version "5.1.5"
+  resolved "https://repository.folio.org/repository/npm-ci-all/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
   dependencies:
     asn1.js "^4.0.0"
     browserify-aes "^1.0.0"
@@ -7674,8 +7724,8 @@ popper.js@^1.14.6:
   resolved "https://repository.folio.org/repository/npm-ci-all/popper.js/-/popper.js-1.15.0.tgz#5560b99bbad7647e9faa475c6b8056621f5a4ff2"
 
 portfinder@^1.0.13:
-  version "1.0.23"
-  resolved "https://repository.folio.org/repository/npm-ci-all/portfinder/-/portfinder-1.0.23.tgz#894db4bcc5daf02b6614517ce89cd21a38226b82"
+  version "1.0.24"
+  resolved "https://repository.folio.org/repository/npm-ci-all/portfinder/-/portfinder-1.0.24.tgz#11efbc6865f12f37624b6531ead1d809ed965cfa"
   dependencies:
     async "^1.5.2"
     debug "^2.2.0"
@@ -8056,16 +8106,16 @@ postcss@^6.0.1, postcss@^6.0.14, postcss@^6.0.18, postcss@^6.0.22, postcss@^6.0.
     supports-color "^5.4.0"
 
 postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.5:
-  version "7.0.17"
-  resolved "https://repository.folio.org/repository/npm-ci-all/postcss/-/postcss-7.0.17.tgz#4da1bdff5322d4a0acaab4d87f3e782436bad31f"
+  version "7.0.18"
+  resolved "https://repository.folio.org/repository/npm-ci-all/postcss/-/postcss-7.0.18.tgz#4b9cda95ae6c069c67a4d933029eddd4838ac233"
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
 prebuild-install@^5.3.0:
-  version "5.3.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/prebuild-install/-/prebuild-install-5.3.0.tgz#58b4d8344e03590990931ee088dd5401b03004c8"
+  version "5.3.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/prebuild-install/-/prebuild-install-5.3.2.tgz#6392e9541ac0b879ef0f22b3d65037417eb2035e"
   dependencies:
     detect-libc "^1.0.3"
     expand-template "^2.0.3"
@@ -8076,11 +8126,10 @@ prebuild-install@^5.3.0:
     node-abi "^2.7.0"
     noop-logger "^0.1.1"
     npmlog "^4.0.1"
-    os-homedir "^1.0.1"
-    pump "^2.0.1"
+    pump "^3.0.0"
     rc "^1.2.7"
-    simple-get "^2.7.0"
-    tar-fs "^1.13.0"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
@@ -8184,8 +8233,8 @@ pseudomap@^1.0.2:
   resolved "https://repository.folio.org/repository/npm-ci-all/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
 psl@^1.1.24:
-  version "1.3.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/psl/-/psl-1.3.1.tgz#d5aa3873a35ec450bc7db9012ad5a7246f6fc8bd"
+  version "1.4.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/psl/-/psl-1.4.0.tgz#5dd26156cdb69fa1fdb8ab1991667d3f80ced7c2"
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -8198,14 +8247,7 @@ public-encrypt@^4.0.0:
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
 
-pump@^1.0.0:
-  version "1.0.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
-
-pump@^2.0.0, pump@^2.0.1:
+pump@^2.0.0:
   version "2.0.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
   dependencies:
@@ -8292,13 +8334,13 @@ quill-delta@^3.6.2:
     fast-diff "1.1.2"
 
 quill@^1.2.6:
-  version "1.3.6"
-  resolved "https://repository.folio.org/repository/npm-ci-all/quill/-/quill-1.3.6.tgz#99f4de1fee85925a0d7d4163b6d8328f23317a4d"
+  version "1.3.7"
+  resolved "https://repository.folio.org/repository/npm-ci-all/quill/-/quill-1.3.7.tgz#da5b2f3a2c470e932340cdbf3668c9f21f9286e8"
   dependencies:
     clone "^2.1.1"
     deep-equal "^1.0.1"
     eventemitter3 "^2.0.3"
-    extend "^3.0.1"
+    extend "^3.0.2"
     parchment "^1.1.4"
     quill-delta "^3.6.2"
 
@@ -8410,6 +8452,13 @@ react-cookie@^2.1.4:
     prop-types "^15.0.0"
     universal-cookie "^2.2.0"
 
+react-copy-to-clipboard@^5.0.1:
+  version "5.0.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
+
 react-deep-force-update@^1.0.0:
   version "1.1.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/react-deep-force-update/-/react-deep-force-update-1.1.2.tgz#3d2ae45c2c9040cbb1772be52f8ea1ade6ca2ee1"
@@ -8455,15 +8504,6 @@ react-dom-factories@^1.0.0:
   version "1.0.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
 
-react-dom@~16.6.3:
-  version "16.6.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.11.2"
-
 react-dom@~16.8.6:
   version "16.8.6"
   resolved "https://repository.folio.org/repository/npm-ci-all/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -8478,6 +8518,12 @@ react-final-form-arrays@^3.1.0:
   resolved "https://repository.folio.org/repository/npm-ci-all/react-final-form-arrays/-/react-final-form-arrays-3.1.1.tgz#39d23e7ede966e418cad209e8fde46da1d603e99"
   dependencies:
     "@babel/runtime" "^7.4.5"
+
+react-final-form-listeners@^1.0.2:
+  version "1.0.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/react-final-form-listeners/-/react-final-form-listeners-1.0.2.tgz#b52da984300281cf1f69a6412e86df6249e2bf1c"
+  dependencies:
+    "@babel/runtime" "^7.1.5"
 
 react-final-form@^6.3.0:
   version "6.3.0"
@@ -8654,12 +8700,11 @@ react-titled@^1.0.0:
     prop-types "^15.5.8"
     react-test-renderer "^16.3.1"
 
-react-to-print@^1.0.21:
-  version "1.0.21"
-  resolved "https://repository.folio.org/repository/npm-ci-all/react-to-print/-/react-to-print-1.0.21.tgz#f6713c5c0ac06dc8c079937e4b7cecd6dbc8d630"
+react-to-print@^2.3.2:
+  version "2.4.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/react-to-print/-/react-to-print-2.4.0.tgz#8f33c9627536501035fc7557d3ad0272df1bcb6b"
   dependencies:
-    prop-types "^15.6.0"
-    react "^16.2.0"
+    prop-types "^15.7.2"
 
 react-transform-catch-errors@^1.0.2:
   version "1.0.2"
@@ -8684,23 +8729,6 @@ react-transition-group@^2.0.0, react-transition-group@^2.2.0, react-transition-g
 react-virtualized-auto-sizer@^1.0.2:
   version "1.0.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
-
-react@^16.2.0:
-  version "16.9.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@~16.6.3:
-  version "16.6.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.11.2"
 
 react@~16.8.6:
   version "16.8.6"
@@ -8763,7 +8791,7 @@ read-pkg@^2.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.1.1:
+"readable-stream@2 || 3", readable-stream@^3.0.1, readable-stream@^3.1.1:
   version "3.4.0"
   resolved "https://repository.folio.org/repository/npm-ci-all/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   dependencies:
@@ -9059,9 +9087,9 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://repository.folio.org/repository/npm-ci-all/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
 
-resolve-pathname@^2.2.0:
-  version "2.2.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
 
 resolve-pkg@^1.0.0:
   version "1.0.0"
@@ -9205,13 +9233,6 @@ sanitize-html@1.18.2:
 sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://repository.folio.org/repository/npm-ci-all/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
-
-scheduler@^0.11.2:
-  version "0.11.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/scheduler/-/scheduler-0.11.3.tgz#b5769b90cf8b1464f3f3cfcafe8e3cd7555a2d6b"
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.13.6:
   version "0.13.6"
@@ -9358,19 +9379,11 @@ simple-concat@^1.0.0:
   version "1.0.0"
   resolved "https://repository.folio.org/repository/npm-ci-all/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
 
-simple-get@^2.7.0:
-  version "2.8.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
-  dependencies:
-    decompress-response "^3.3.0"
-    once "^1.3.1"
-    simple-concat "^1.0.0"
-
 simple-get@^3.0.3:
-  version "3.0.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/simple-get/-/simple-get-3.0.3.tgz#924528ac3f9d7718ce5e9ec1b1a69c0be4d62efa"
+  version "3.1.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/simple-get/-/simple-get-3.1.0.tgz#b45be062435e50d159540b576202ceec40b9c6b3"
   dependencies:
-    decompress-response "^3.3.0"
+    decompress-response "^4.2.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -9746,18 +9759,18 @@ string.prototype.trim@^1.1.2:
     function-bind "^1.1.1"
 
 string.prototype.trimleft@^2.0.0:
-  version "2.0.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz#68b6aa8e162c6a80e76e3a8a0c2e747186e271ff"
+  version "2.1.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz#6cc47f0d7eb8d62b0f3701611715a3954591d634"
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.0.2"
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
 string.prototype.trimright@^2.0.0:
-  version "2.0.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz#ab4a56d802a01fbe7293e11e84f24dc8164661dd"
+  version "2.1.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz#669d164be9df9b6f7559fa8e89945b168a5a6c58"
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.0.2"
+    define-properties "^1.1.3"
+    function-bind "^1.1.1"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -9938,34 +9951,32 @@ tapable@^1.0.0, tapable@^1.0.0-beta.5, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://repository.folio.org/repository/npm-ci-all/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
 
-tar-fs@^1.13.0:
-  version "1.16.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
+tar-fs@^2.0.0:
+  version "2.0.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/tar-fs/-/tar-fs-2.0.0.tgz#677700fc0c8b337a78bee3623fdc235f21d7afad"
   dependencies:
-    chownr "^1.0.1"
+    chownr "^1.1.1"
     mkdirp "^0.5.1"
-    pump "^1.0.0"
-    tar-stream "^1.1.2"
+    pump "^3.0.0"
+    tar-stream "^2.0.0"
 
-tar-stream@^1.1.2:
-  version "1.6.2"
-  resolved "https://repository.folio.org/repository/npm-ci-all/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
+tar-stream@^2.0.0:
+  version "2.1.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/tar-stream/-/tar-stream-2.1.0.tgz#d1aaa3661f05b38b5acc9b7020efdca5179a2cc3"
   dependencies:
-    bl "^1.0.0"
-    buffer-alloc "^1.2.0"
-    end-of-stream "^1.0.0"
+    bl "^3.0.0"
+    end-of-stream "^1.4.1"
     fs-constants "^1.0.0"
-    readable-stream "^2.3.0"
-    to-buffer "^1.1.1"
-    xtend "^4.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^4, tar@^4.4.8:
-  version "4.4.10"
-  resolved "https://repository.folio.org/repository/npm-ci-all/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  version "4.4.11"
+  resolved "https://repository.folio.org/repository/npm-ci-all/tar/-/tar-4.4.11.tgz#7ac09801445a3cf74445ed27499136b5240ffb73"
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.3.5"
+    minipass "^2.6.4"
     minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
@@ -9998,8 +10009,8 @@ terser-webpack-plugin@^1.4.1:
     worker-farm "^1.7.0"
 
 terser@^4.1.2:
-  version "4.2.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/terser/-/terser-4.2.1.tgz#1052cfe17576c66e7bc70fcc7119f22b155bdac1"
+  version "4.3.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/terser/-/terser-4.3.1.tgz#09820bcb3398299c4b48d9a86aefc65127d0ed65"
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -10095,10 +10106,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://repository.folio.org/repository/npm-ci-all/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
-to-buffer@^1.1.1:
-  version "1.1.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
-
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://repository.folio.org/repository/npm-ci-all/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
@@ -10138,6 +10145,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://repository.folio.org/repository/npm-ci-all/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 toidentifier@1.0.0:
   version "1.0.0"
@@ -10437,9 +10448,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-value-equal@^0.4.0:
-  version "0.4.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
 
 vary@~1.1.2:
   version "1.1.2"
@@ -10511,8 +10522,8 @@ webapp-webpack-plugin@^2.6.1:
     tapable "^1.1.3"
 
 webpack-bundle-analyzer@^3.3.2:
-  version "3.4.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz#430544c7ba1631baccf673475ca8300cb74a3c47"
+  version "3.5.0"
+  resolved "https://repository.folio.org/repository/npm-ci-all/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.5.0.tgz#c82130a490a05f9267aa5956871aef574dff5074"
   dependencies:
     acorn "^6.0.7"
     acorn-walk "^6.1.1"
@@ -10577,8 +10588,8 @@ webpack-virtual-modules@^0.1.10:
     debug "^3.0.0"
 
 webpack@^4.0.0, webpack@^4.10.2:
-  version "4.39.3"
-  resolved "https://repository.folio.org/repository/npm-ci-all/webpack/-/webpack-4.39.3.tgz#a02179d1032156b713b6ec2da7e0df9d037def50"
+  version "4.40.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/webpack/-/webpack-4.40.2.tgz#d21433d250f900bf0facbabe8f50d585b2dc30a7"
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"
@@ -10848,9 +10859,9 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://repository.folio.org/repository/npm-ci-all/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
 
-zen-observable-ts@^0.8.19:
-  version "0.8.19"
-  resolved "https://repository.folio.org/repository/npm-ci-all/zen-observable-ts/-/zen-observable-ts-0.8.19.tgz#c094cd20e83ddb02a11144a6e2a89706946b5694"
+zen-observable-ts@^0.8.20:
+  version "0.8.20"
+  resolved "https://repository.folio.org/repository/npm-ci-all/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz#44091e335d3fcbc97f6497e63e7f57d5b516b163"
   dependencies:
     tslib "^1.9.3"
     zen-observable "^0.8.0"


### PR DESCRIPTION
Update #master to stripes `v2.10.1` and ui-users `v2.25.1`. This stripes-components update changes the structure of the MCL component and integration tests that rely on this component are distributed across many modules, including ui-users and platform-core, hence merging the platform's test updates simultaneously with the stripes-components and ui-users updates. 

* react 16.8
  We have many modules that make use of hooks, so we need a react
  instance that provides hooks
* @folio/stripes 2.10.1
  Introduce many change to the `<MultiColumnList>` component which 
  must be reflected in integration test updates across multiple repositories,
  including ui-users and platform-core.
* @folio/checkin 1.9
  Update the react-to-print version to accept React via peerDependencies
  in order to avoid bundling and hoisting a nested copy.
* @folio/circulation 1.11
  Update the react-to-print version to accept React via peerDependencies
  in order to avoid bundling and hoisting a nested copy.
* @folio/tenant-settings 2.13.0
  Integration test updates reflect changes in `<MultiColumnList>`.
* @folio/users 2.25.1
  Integration test updates reflect changes in `<MultiColumnList>`.

Replaces #383, #390, #393, #395, #398 

Refs [UIIN-678](https://issues.folio.org/browse/UIIN-678), [STCOM-363](https://issues.folio.org/browse/STCOM-363)