### PR TITLE
STCOM-581 provide react-router as a peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "react": "~16.8.6",
     "react-dom": "~16.8.6",
     "react-redux": "^5.1.1",
+    "react-router": "^5.0.1",
+    "react-router-dom": "^5.0.1",
     "redux": "^3.7.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,8 +746,8 @@
     redux-form "^7.0.3"
 
 "@folio/users@>=2.17.0":
-  version "2.26.1000800"
-  resolved "https://repository.folio.org/repository/npm-folioci/@folio/users/-/users-2.26.1000800.tgz#56b55d565dc181c650dbb5614e3eccfefc4c5ca0"
+  version "2.26.1000801"
+  resolved "https://repository.folio.org/repository/npm-folioci/@folio/users/-/users-2.26.1000801.tgz#a95042dfc7fad591af63013335156cb793d0d751"
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.0"
     hashcode "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2982,8 +2982,8 @@ commander@2.20.0:
   resolved "https://repository.folio.org/repository/npm-ci-all/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
 
 commander@^2.11.0, commander@^2.15.1, commander@^2.18.0, commander@^2.20.0, commander@^2.9.0:
-  version "2.20.1"
-  resolved "https://repository.folio.org/repository/npm-ci-all/commander/-/commander-2.20.1.tgz#3863ce3ca92d0831dcf2a102f5fb4b5926afd0f9"
+  version "2.20.3"
+  resolved "https://repository.folio.org/repository/npm-ci-all/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
 
 commander@~2.19.0:
   version "2.19.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10527,8 +10527,8 @@ webpack-virtual-modules@^0.1.10:
     debug "^3.0.0"
 
 webpack@^4.0.0, webpack@^4.10.2:
-  version "4.41.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/webpack/-/webpack-4.41.0.tgz#db6a254bde671769f7c14e90a1a55e73602fc70b"
+  version "4.41.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/webpack/-/webpack-4.41.1.tgz#5388dd3047d680d5d382a84249fd4750e87372fd"
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
     "@webassemblyjs/helper-module-context" "1.8.5"


### PR DESCRIPTION
`react-router` and `react-router-dom` need to be provided by the platform as
dependencies for the platform's constituent modules to consume as
peerDependencies in order to guarantee that all modules are on the same
version. Modules may pass `<Link>` instances across module borders so we
need to be certain all modules agree on the same version of `<Link>` in
order to avoid crashing React.

Refs [STCOM-581](https://issues.folio.org/browse/STCOM-581)