### PR TITLE
UITEST-70 be less markupy, more semantic

### DIFF
--- a/test/ui-testing/new-proxy.js
+++ b/test/ui-testing/new-proxy.js
@@ -59,7 +59,7 @@ module.exports.test = function foo(uiTestCtx) {
       });
 
       it('should add a proxy for user 1', (done) => {
-        const selector = '#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"] div[role="gridcell"]:nth-child(3)';
+        const selector = '#OverlayContainer #list-plugin-find-user [role="row"][aria-rowindex="2"] [role="gridcell"]:nth-child(3)';
         nightmare
           .wait('#input-user-search')
           .type('#input-user-search', '0')
@@ -89,8 +89,8 @@ module.exports.test = function foo(uiTestCtx) {
           }, selector)
           .then(barcode => {
             nightmare
-              .wait('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
-              .click('#OverlayContainer #list-plugin-find-user div[role="row"][aria-rowindex="2"]')
+              .wait('#OverlayContainer #list-plugin-find-user [role="row"][aria-rowindex="2"]')
+              .click('#OverlayContainer #list-plugin-find-user [role="row"][aria-rowindex="2"]')
               .wait('#clickable-save')
               .click('#clickable-save')
               .then(done)
@@ -120,8 +120,8 @@ module.exports.test = function foo(uiTestCtx) {
           .wait('button[type=submit]')
           .click('button[type=submit]')
           .wait('#list-users[data-total-count="1"]')
-          .wait('#list-users div[role="row"][aria-rowindex="2"] > a')
-          .click('#list-users div[role="row"][aria-rowindex="2"] > a')
+          .wait('#list-users [role="row"][aria-rowindex="2"] > a')
+          .click('#list-users [role="row"][aria-rowindex="2"] > a')
           .wait('#accordion-toggle-button-proxySection')
           .wait('#clickable-edituser')
           .click('#clickable-edituser')
@@ -129,7 +129,7 @@ module.exports.test = function foo(uiTestCtx) {
           .click('#accordion-toggle-button-proxy')
           .wait('#proxy div[class*=sectionActions] button')
           .click('#proxy div[class*=sectionActions] button')
-          .wait('#OverlayContainer div[role="dialog"]')
+          .wait('#OverlayContainer [role="dialog"]')
           .wait('#deletesponsors-confirmation-footer')
           .wait('#clickable-deletesponsors-confirmation-confirm')
           .click('#clickable-deletesponsors-confirmation-confirm')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5120,8 +5120,8 @@ gzip-size@^5.0.0:
     pify "^4.0.1"
 
 handlebars@^4.0.3, handlebars@^4.1.2:
-  version "4.4.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/handlebars/-/handlebars-4.4.0.tgz#22e1a897c5d83023d39801f35f6b65cf97ed8b25"
+  version "4.4.2"
+  resolved "https://repository.folio.org/repository/npm-ci-all/handlebars/-/handlebars-4.4.2.tgz#8810a9821a9d6d52cb2f57d326d6ce7c3dfe741d"
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -6229,8 +6229,8 @@ json5@^1.0.1:
     minimist "^1.2.0"
 
 json5@^2.1.0:
-  version "2.1.0"
-  resolved "https://repository.folio.org/repository/npm-ci-all/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
+  version "2.1.1"
+  resolved "https://repository.folio.org/repository/npm-ci-all/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
   dependencies:
     minimist "^1.2.0"
 


### PR DESCRIPTION
Same as #404 which merged to `#snapshot` and #419 which merged to `#master`.
The MCL default formatter changed in [PR 1054](https://github.com/folio-org/stripes-components/pull/1054) in stripes-components.

Refs [UITEST-70](https://issues.folio.org/browse/UITEST-70)