### PR TITLE
Revert "STCOM-581 provide react-router as a peerDep"

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
     "react": "~16.8.6",
     "react-dom": "~16.8.6",
     "react-redux": "^5.1.1",
-    "react-router": "^5.0.1",
-    "react-router-dom": "^5.0.1",
     "redux": "^3.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts folio-org/platform-core#406

When individual apps still include react-router v4, this causes an error:
```
ERROR:Invariant failed: You should not use <Switch> outside a <Router>
```