### PR TITLE
CIRC-495 overdue policy is required

### DIFF
--- a/test/ui-testing/exercise.js
+++ b/test/ui-testing/exercise.js
@@ -25,28 +25,14 @@ module.exports.test = (uiTestCtx) => {
       });
 
       let initialRules = '';
-      it('should configure default circulation rules', (done) => {
-        nightmare
-          .wait('a[href="/settings/circulation"]')
-          .click('a[href="/settings/circulation"]')
-          .wait('a[href="/settings/circulation/rules"]')
-          .click('a[href="/settings/circulation/rules"]')
-          .wait('#form-loan-rules')
-          .wait(1000)
-          .evaluate(() => {
-            const defaultRules = document.getElementsByClassName('CodeMirror')[0].CodeMirror.getValue();
-            const value = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy \nm book: l example-loan-policy r allow-all n alternate-notice-policy';
-            document.getElementsByClassName('CodeMirror')[0].CodeMirror.setValue(value);
-            return defaultRules;
+
+      it('should configure circulation rules', (done) => {
+        const rules = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy o test-overdue \nm book: l example-loan-policy r allow-all n alternate-notice-policy o test-overdue';
+        helpers.setCirculationRules(nightmare, rules)
+          .then(oldRules => {
+            initialRules = oldRules;
           })
-          .then((rules) => {
-            nightmare
-              .wait('#clickable-save-loan-rules')
-              .click('#clickable-save-loan-rules')
-              .then(done)
-              .catch(done);
-            initialRules = rules;
-          })
+          .then(done)
           .catch(done);
       });
 
@@ -206,25 +192,9 @@ module.exports.test = (uiTestCtx) => {
         helpers.clickSettings(nightmare, done);
       });
 
-      it('should restore initial circulation rules', (done) => {
-        nightmare
-          .wait('a[href="/settings/circulation"]')
-          .click('a[href="/settings/circulation"]')
-          .wait('a[href="/settings/circulation/rules"]')
-          .click('a[href="/settings/circulation/rules"]')
-          .wait('#form-loan-rules')
-          .wait(1000)
-          .evaluate((r) => {
-            document.getElementsByClassName('CodeMirror')[0].CodeMirror.setValue(r);
-            return r;
-          }, initialRules)
-          .then(() => {
-            nightmare
-              .wait('#clickable-save-loan-rules')
-              .click('#clickable-save-loan-rules')
-              .then(done)
-              .catch(done);
-          })
+      it('should restore the circulation rules', (done) => {
+        helpers.setCirculationRules(nightmare, initialRules)
+          .then(() => done())
           .catch(done);
       });
 

--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -238,7 +238,7 @@ module.exports.test = (uiTestCtx) => {
           });
 
           it('Apply the loan policy created as a circulation rule to material-type book', (done) => {
-            const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} \nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName}`;
+            const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} o overdue-test\nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName} o overdue-test`;
             helpers.setCirculationRules(nightmare, rules)
               .then(oldRules => {
                 loanRules = oldRules;

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -29,7 +29,7 @@ module.exports.test = function uiTest(uiTestCtx) {
       });
 
       it('should configure default circulation rules', (done) => {
-        const newRules = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy \nm book: l example-loan-policy r allow-all n alternate-notice-policy';
+        const newRules = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy o overdue-test\nm book: l example-loan-policy r allow-all n alternate-notice-policy o overdue-test';
         setCirculationRules(nightmare, newRules)
           .then(oldRules => {
             initialRules = oldRules;


### PR DESCRIPTION
Circulation rule syntax is not technically part of the API surface, so
this new requirement to have an overdue policy with every rule snuck in
without anybody on the UI side noticing.

These changes provide a dummy policy, `o test-overdue`, in the rules but
do not actually handle creating and removing such a policy in the UI.
We should add that.

Refs [CIRC-495](https://issues.folio.org/browse/CIRC-495)