### PR TITLE
FOLIO-2332 lock svgo to v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "@folio/stripes-cli": "^1.13.0",
     "eslint": "^6.2.1",
     "moment": "^2.22.2"
+  },
+  "resolutions": {
+    "svgo": "1.3.0"
   }
 }


### PR DESCRIPTION
Somebody gave svgo five infinity stones and it's using them to
destory the web in v1.3.1. Luckily, I have the time stone so we
can pin ourselves in the happier times of v1.3.0.

Props to @Yurii-Danylenko for diagnosing the issue.

Refs [FOLIO-2332](https://issues.folio.org/browse/FOLIO-2332)