### PR TITLE
add lost-item policy to circ rules

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -47,30 +47,7 @@ module.exports.test = (uiTestCtx) => {
     let barcode = '';
 
     describe(
-      // eslint-disable-next-line quotes
-      `Login > \
-      Update settings >\
-      Create loan policy >\
-      Apply circulation rule >\
-      Find Active user >\
-      Create inventory record >\
-      Create holdings record >\
-      Create item record >\
-      Checkout item >\
-      Confirm checkout >\
-      Renew success >\
-      Renew failure >\
-      Renew failure >\
-      Create fixedDueDateSchedule >\
-      Assign fdds to loan policy >\
-      Renew failure > \
-      // Edit loan policy >\
-      // Renew failure >\
-      Check in >\
-      Restore the circulation rules >\
-      delete loan policy >\
-      delete fixedDueDateSchedule >\
-      logout\n`,
+      'Validate renewal success/failure with a variety of loan policies, schedules, and circulation rules',
       function descStart() {
         describe('Login', () => {
           it(`should login as ${config.username}/${config.password}`, (done) => {
@@ -238,7 +215,7 @@ module.exports.test = (uiTestCtx) => {
           });
 
           it('Apply the loan policy created as a circulation rule to material-type book', (done) => {
-            const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} o overdue-test\nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName} o overdue-test`;
+            const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} o overdue-test i lost-item-test\nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName} o overdue-test i lost-item-test`;
             helpers.setCirculationRules(nightmare, rules)
               .then(oldRules => {
                 loanRules = oldRules;


### PR DESCRIPTION
A backend change now requires including a "lost item" policy reference
in every rule. Who knew? I LOVE it that we don't have a way to version
circ-rule syntax changes in our API. It's totally my favorite thing.
`</sarcasm>`. OK, I get why it doesn't work that way because the API
endpoint just accepts a text-string not a JSON object, but that still
sucks.

All I want for Christmas is an API that accepts circulation rules as
JSON instead of as a string. Or a hippopotamus. A hippopotamus is no
ignormaus and would sing me this sweet serenade:
JSON, JSON, glorious JSON
Nothing quite like for spec'ing the types in
Ugh. POST with me, POST
A string to the host
Until we can send it some glorious JSON.

Alas, I fear somebody is about to punch out my two front teeth and leave
me instead a big old box of rocks.