### PR TITLE
FOLIO-2440 create temporary policies

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -23,11 +23,14 @@ module.exports.test = (uiTestCtx) => {
       barcodeCell.parentElement.querySelector('input[type="checkbox"]').click();
     };
 
+    let initialRules = '';
     let userid = 'user';
     const policyName = `test-policy-${Math.floor(Math.random() * 10000)}`;
     const scheduleName = `test-schedule-${Math.floor(Math.random() * 10000)}`;
     const noticePolicyName = `test-notice-policy-${Math.floor(Math.random() * 10000)}`;
     const requestPolicyName = `test-request-policy-${Math.floor(Math.random() * 10000)}`;
+    const overdueFinePolicyName = `test-overdue-fine-policy-${Math.floor(Math.random() * 10000)}`;
+    const lostItemFeePolicyName = `test-lost-item-fee-policy-${Math.floor(Math.random() * 10000)}`;
 
     const renewalLimit = 1;
     const loanPeriod = 2;
@@ -43,404 +46,321 @@ module.exports.test = (uiTestCtx) => {
     const dayAfterValue = moment()
       .add(4, 'days')
       .format('MM/DD/YYYY');
-    let loanRules = '';
     let barcode = '';
 
+    describe('Login', () => {
+      it(`should login as ${config.username}/${config.password}`, (done) => {
+        helpers.login(nightmare, config, done);
+      });
+    });
+
+    describe('Update settings', () => {
+      it('should navigate to settings', (done) => {
+        helpers.clickSettings(nightmare, done);
+      });
+
+      it('should configure checkout for barcode and username', (done) => {
+        helpers.circSettingsCheckoutByBarcodeAndUsername(nightmare, config, done);
+      });
+
+      it('should configure US English locale and timezone', (done) => {
+        helpers.setUsEnglishLocale(nightmare, config, done);
+      });
+
+      describe('addOverdueFinePolicy', function foo() {
+        helpers.addOverdueFinePolicy(nightmare, overdueFinePolicyName);
+      });
+
+      describe('addLostItemFeePolicy', function foo() {
+        helpers.addLostItemFeePolicy(nightmare, lostItemFeePolicyName, 10, 'm');
+      });
+
+      describe('addNoticePolicy', function foo() {
+        helpers.addNoticePolicy(nightmare, noticePolicyName);
+      });
+
+      describe('addLoanPolicy', function foo() {
+        helpers.addLoanPolicy(nightmare, policyName, loanPeriod, renewalLimit);
+      });
+
+      describe('addRequestPolicy', function foo() {
+        helpers.addRequestPolicy(nightmare, requestPolicyName);
+      });
+
+      describe('it should configure circulation rules', function foo() {
+        it('set new rules circulation rules', (done) => {
+          const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} o ${overdueFinePolicyName} i ${lostItemFeePolicyName}\nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName} o ${overdueFinePolicyName} i ${lostItemFeePolicyName}`;
+          helpers.setCirculationRules(nightmare, rules)
+            .then(oldRules => {
+              initialRules = oldRules;
+            })
+            .then(done)
+            .catch(done);
+        });
+      });
+    });
+
+    describe('Find Active user', () => {
+      it('should navigate to users', (done) => {
+        helpers.clickApp(nightmare, done, 'users');
+      });
+
+      it('should find an active user ', (done) => {
+        helpers.findActiveUserBarcode(nightmare, 'faculty')
+          .then(bc => {
+            done();
+            console.log(`\t    Found user ${bc}`);
+            userid = bc;
+          })
+          .catch(done);
+      });
+    });
+
     describe(
-      'Validate renewal success/failure with a variety of loan policies, schedules, and circulation rules',
-      function descStart() {
-        describe('Login', () => {
-          it(`should login as ${config.username}/${config.password}`, (done) => {
-            helpers.login(nightmare, config, done);
-          });
-        });
+      'Create inventory > holdings > item records',
+      () => {
+        barcode = helpers.createInventory(nightmare, config, 'Soul station / Hank Mobley');
+      }
+    );
 
-        describe('Update settings', () => {
-          it('should configure checkout for barcode and username', (done) => {
-            helpers.circSettingsCheckoutByBarcodeAndUsername(nightmare, config, done);
-          });
+    describe('Checkout item', () => {
+      // if we don't wait a second after creating the item record,
+      // we seem to get stuck there and cannot navigate to checkout.
+      // does this make any sense at all? no. no it does not. and yet.
+      it('should navigate to checkout', (done) => {
+        helpers.clickApp(nightmare, done, 'checkout', 1000);
+      });
 
-          it('should configure US English locale and timezone', (done) => {
-            helpers.setUsEnglishLocale(nightmare, config, done);
-          });
-        });
+      it(`should check out ${barcode} to ${userid}`, (done) => {
+        helpers.checkout(nightmare, done, barcode, userid);
+      });
+    });
 
-        describe('Create loan policy', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
+    describe('Confirm checkout', () => {
+      it('should navigate to users', (done) => {
+        helpers.clickApp(nightmare, done, 'users');
+      });
 
-          it('should reach "Create loan policy" page', (done) => {
+      it(`should find ${barcode} in ${userid}'s open loans`, (done) => {
+        nightmare
+          .wait('#input-user-search')
+          .type('#input-user-search', '0')
+          .wait('#clickable-reset-all')
+          .click('#clickable-reset-all')
+          .insert('#input-user-search', userid)
+          .wait('button[type=submit]')
+          .click('button[type=submit]')
+          .wait('#list-users[data-total-count="1"] a[role="row"]')
+          .click('#list-users[data-total-count="1"] a[role="row"]')
+          .wait('#clickable-viewcurrentloans')
+          .click('#clickable-viewcurrentloans')
+          .wait('#list-loanshistory:not([data-total-count="0"])')
+          .wait(findBarcodeCell, barcode)
+          .then(done)
+          .catch(done);
+      });
+    });
+
+    describe('Renew success', () => {
+      it('should renew the loan and succeed', (done) => {
+        nightmare
+          .wait('#list-loanshistory')
+          .wait(findBarcodeCell, barcode)
+          .evaluate(tickRenewCheckbox, barcode)
+          .then(() => {
             nightmare
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/loan-policies"]')
-              .click('a[href="/settings/circulation/loan-policies"]')
-              .wait('#clickable-create-entry')
-              .click('#clickable-create-entry')
+              .wait('#renew-all')
+              .click('#renew-all')
+              .wait('div[class^="calloutBase"]')
               .then(done)
               .catch(done);
-          });
+          })
+          .catch(done);
+      });
+    });
 
-          it(`should create a new loan policy (${policyName}) with renewalLimit of 1`, (done) => {
+    describe('Renew failure', () => {
+      it('should renew the loan second time and hit the renewal limit', (done) => {
+        nightmare
+          .wait('#list-loanshistory')
+          .wait(findBarcodeCell, barcode)
+          .evaluate(tickRenewCheckbox, barcode)
+          .then(() => {
             nightmare
-              .wait('#input_policy_name')
-              .type('#input_policy_name', policyName)
+              .wait('#renew-all')
+              .click('#renew-all')
+              .wait('#bulk-renewal-modal')
+              .wait(333)
+              .evaluate(() => {
+                const errorMsg = document.querySelectorAll('#bulk-renewal-modal [role="gridcell"]')[0].textContent;
+                if (errorMsg === null) {
+                  throw new Error('Should throw an error as the renewalLimit is reached');
+                } else if (!errorMsg.match('Item not renewed:loan at maximum renewal number')) {
+                  throw new Error('Expected only the renewal failure error message');
+                }
+              }, policyName)
+              .then(done)
+              .catch(done);
+          })
+          .catch(done);
+      });
+    });
+
+    describe('Renew failure', () => {
+      it('should navigate to settings', (done) => {
+        helpers.clickSettings(nightmare, done);
+      });
+
+      it('should reach "loan policy settings" page', (done) => {
+        nightmare
+          .wait('a[href="/settings/circulation"]')
+          .click('a[href="/settings/circulation"]')
+          .wait('a[href="/settings/circulation/loan-policies"]')
+          .click('a[href="/settings/circulation/loan-policies"]')
+          .then(done)
+          .catch(done);
+      });
+
+      it('edit loan policy to renew from system date', (done) => {
+        nightmare
+          .wait('div.hasEntries')
+          .evaluate((pn) => {
+            const index = Array.from(
+              document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+            )
+              .findIndex(e => e.textContent === pn);
+
+            if (index === -1) {
+              throw new Error(`Could not find the loan policy ${pn} to edit`);
+            }
+
+            // CSS selectors are 1-based, which is just totally awesome.
+            return index + 1;
+          }, policyName)
+          .then((entryIndex) => {
+            nightmare
+              .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+              .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+              .wait('#clickable-edit-item')
+              .click('#clickable-edit-item')
+              .wait('#input_allowed_renewals')
+              .type('#input_allowed_renewals', 2)
+              .wait('#select_renew_from')
+              .select('#select_renew_from', 'SYSTEM_DATE')
+              .wait('#footer-save-entity')
+              .click('#footer-save-entity')
+              .wait(1000)
+              .evaluate(() => {
+                const sel = document.querySelector('div[class^="textfieldError"]');
+                if (sel) {
+                  throw new Error(sel.textContent);
+                }
+              })
+              .wait(() => !document.querySelector('#footer-save-entity'))
+              .then(done)
+              .catch(done);
+          })
+          .catch(done);
+      });
+
+      it('should navigate to users', (done) => {
+        helpers.clickApp(nightmare, done, 'users', 1000);
+      });
+
+      it('should fail the renewal', (done) => {
+        nightmare
+          .wait(findBarcodeCell, barcode)
+          .evaluate(tickRenewCheckbox, barcode)
+          .then(() => {
+            nightmare
+              .wait('#renew-all')
+              .click('#renew-all')
+              .wait('#bulk-renewal-modal')
+              .wait(1000)
+              .evaluate(() => {
+                const expectedMessage = 'Item not renewed:renewal would not change the due date';
+                const errorMsg = document.querySelectorAll('#bulk-renewal-modal div[role="gridcell"]')[0].textContent;
+                if (errorMsg === null) {
+                  throw new Error('Should throw an error as the renewalLimit is reached');
+                } else if (!errorMsg.match(expectedMessage)) {
+                  throw new Error(`Expected "${expectedMessage}"; got "${errorMsg}"`);
+                }
+              })
+              .then(done)
+              .catch(done);
+          })
+          .catch(done);
+      });
+    });
+
+    describe('Create fixed due date schedule', () => {
+      it('should navigate to settings', (done) => {
+        helpers.clickSettings(nightmare, done);
+      });
+
+      it('should create a new fixed due date schedule', (done) => {
+        nightmare
+          .wait('a[href="/settings/circulation"]')
+          .click('a[href="/settings/circulation"]')
+          .wait('a[href="/settings/circulation/fixed-due-date-schedules"]')
+          .click('a[href="/settings/circulation/fixed-due-date-schedules"]')
+          .wait('#clickable-create-entry')
+          .click('#clickable-create-entry')
+          .wait('#input_schedule_name')
+          .type('#input_schedule_name', scheduleName)
+          .wait('input[name="schedules[0].from"]')
+          .insert('input[name="schedules[0].from"]', tomorrowValue)
+          .wait('input[name="schedules[0].to"]')
+          .insert('input[name="schedules[0].to"]', dayAfterValue)
+          .wait('input[name="schedules[0].due"]')
+          .insert('input[name="schedules[0].due"]', nextMonthValue)
+          .wait('#clickable-save-fixedDueDateSchedule')
+          .click('#clickable-save-fixedDueDateSchedule')
+          .wait(1000)
+          .evaluate(() => {
+            const sel = document.querySelector('div[class^="feedbackError"]');
+            if (sel) {
+              throw new Error(sel.textContent);
+            }
+          })
+          .then(done)
+          .catch(done);
+      });
+    });
+
+    describe('Assign fixed due date schedule to loan policy', () => {
+      it(`assign the fixed due date schedule (${scheduleName}) to the loan policy`, (done) => {
+        nightmare
+          .wait('a[href="/settings/circulation/loan-policies"]')
+          .click('a[href="/settings/circulation/loan-policies"]')
+          .wait('div.hasEntries')
+          .evaluate((pn) => {
+            const index = Array.from(
+              document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+            )
+              .findIndex(e => e.textContent === pn);
+
+            if (index === -1) {
+              throw new Error(`Could not find the loan policy ${pn} to edit`);
+            }
+
+            // CSS selectors are 1-based, which is just totally awesome.
+            return index + 1;
+          }, policyName)
+          .then((entryIndex) => {
+            nightmare
+              .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+              .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+              .wait('#clickable-edit-item')
+              .click('#clickable-edit-item')
               .wait('#input_loan_profile')
-              .select('#input_loan_profile', 'Rolling')
-              .wait('input[name="loansPolicy.period.duration"')
-              .type('input[name="loansPolicy.period.duration"', loanPeriod)
-              .wait('select[name="loansPolicy.period.intervalId"]')
-              .select('select[name="loansPolicy.period.intervalId"]', 'Minutes')
+              .type('#input_loan_profile', 'fi')
+              .wait('#input_loansPolicy_fixedDueDateSchedule')
+              .type('#input_loansPolicy_fixedDueDateSchedule', scheduleName)
               .wait('select[name="loansPolicy.closedLibraryDueDateManagementId"]')
               .type('select[name="loansPolicy.closedLibraryDueDateManagementId"]', 'keep')
-              .wait('#input_allowed_renewals')
-              .type('#input_allowed_renewals', renewalLimit)
-              .wait('#select_renew_from')
-              .type('#select_renew_from', 'cu')
               .wait('#footer-save-entity')
               .click('#footer-save-entity')
-              .wait(1000)
-              .evaluate(() => {
-                const sel = document.querySelector('div[class^="textfieldError"]');
-                if (sel) {
-                  throw new Error(sel.textContent);
-                }
-              })
-              .wait(() => {
-                return !document.querySelector('#footer-save-entity');
-              })
-              .then(done)
-              .catch(done);
-          });
-        });
-
-        describe('Create notice policy', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
-
-          it('should reach "Create notice policy" page', (done) => {
-            nightmare
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/notice-policies"]')
-              .click('a[href="/settings/circulation/notice-policies"]')
-              .wait('#clickable-create-entry')
-              .click('#clickable-create-entry')
-              .then(done)
-              .catch(done);
-          });
-
-          it(`should create a new notice policy (${noticePolicyName})`, (done) => {
-            nightmare
-              .wait('#notice_policy_name')
-              .type('#notice_policy_name', noticePolicyName)
-              .wait('#notice_policy_active')
-              .check('#notice_policy_active')
-              .wait('#footer-save-entity')
-              .click('#footer-save-entity')
-              .wait(1000)
-              .evaluate(() => {
-                const sel = document.querySelector('div[class^="textfieldError"]');
-                if (sel) {
-                  throw new Error(sel.textContent);
-                }
-              })
-              .wait(() => {
-                return !document.querySelector('#footer-save-entity');
-              })
-              .then(done)
-              .catch(done);
-          });
-        });
-
-        describe('Create request policy', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
-
-          it('should reach "Create request policy" page', (done) => {
-            nightmare
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/request-policies"]')
-              .click('a[href="/settings/circulation/request-policies"]')
-              .wait('#clickable-create-entry')
-              .click('#clickable-create-entry')
-              .then(done)
-              .catch(done);
-          });
-
-          it(`should create a new request policy (${requestPolicyName})`, (done) => {
-            nightmare
-              .wait('#request_policy_name')
-              .type('#request_policy_name', requestPolicyName)
-              .wait('#hold-checkbox')
-              .check('#hold-checkbox')
-              .wait('#page-checkbox')
-              .check('#page-checkbox')
-              .wait('#recall-checkbox')
-              .check('#recall-checkbox')
-              .wait('#footer-save-entity')
-              .click('#footer-save-entity')
-              .wait(1000)
-              .evaluate(() => {
-                const sel = document.querySelector('div[class^="textfieldError"]');
-                if (sel) {
-                  throw new Error(sel.textContent);
-                }
-              })
-              .wait(() => {
-                return !document.querySelector('#footer-save-entity');
-              })
-              .then(done)
-              .catch(done);
-          });
-        });
-
-        describe('Apply circulation rule', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
-
-          it('should reach "Circulation rules" page', (done) => {
-            nightmare
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/rules"]')
-              .click('a[href="/settings/circulation/rules"]')
-              .then(done)
-              .catch(done);
-          });
-
-          it('Apply the loan policy created as a circulation rule to material-type book', (done) => {
-            const rules = `priority: t, s, c, b, a, m, g \nfallback-policy: l example-loan-policy r ${requestPolicyName} n ${noticePolicyName} o overdue-test i lost-item-test\nm book: l ${policyName} r ${requestPolicyName} n ${noticePolicyName} o overdue-test i lost-item-test`;
-            helpers.setCirculationRules(nightmare, rules)
-              .then(oldRules => {
-                loanRules = oldRules;
-              })
-              .then(done)
-              .catch(done);
-          });
-        });
-
-        describe('Find Active user', () => {
-          it('should navigate to users', (done) => {
-            helpers.clickApp(nightmare, done, 'users');
-          });
-
-          it('should find an active user ', (done) => {
-            helpers.findActiveUserBarcode(nightmare, 'faculty')
-              .then(bc => {
-                done();
-                console.log(`\t    Found user ${bc}`);
-                userid = bc;
-              })
-              .catch(done);
-          });
-        });
-
-        describe(
-          'Create inventory > holdings > item records',
-          () => {
-            barcode = helpers.createInventory(nightmare, config, 'Soul station / Hank Mobley');
-          }
-        );
-
-        describe('Checkout item', () => {
-          // if we don't wait a second after creating the item record,
-          // we seem to get stuck there and cannot navigate to checkout.
-          // does this make any sense at all? no. no it does not. and yet.
-          it('should navigate to checkout', (done) => {
-            helpers.clickApp(nightmare, done, 'checkout', 1000);
-          });
-
-          it(`should check out ${barcode} to ${userid}`, (done) => {
-            helpers.checkout(nightmare, done, barcode, userid);
-          });
-        });
-
-        describe('Confirm checkout', () => {
-          it('should navigate to users', (done) => {
-            helpers.clickApp(nightmare, done, 'users');
-          });
-
-          it(`should find ${barcode} in ${userid}'s open loans`, (done) => {
-            nightmare
-              .wait('#input-user-search')
-              .type('#input-user-search', '0')
-              .wait('#clickable-reset-all')
-              .click('#clickable-reset-all')
-              .insert('#input-user-search', userid)
-              .wait('button[type=submit]')
-              .click('button[type=submit]')
-              .wait('#list-users[data-total-count="1"] a[role="row"]')
-              .click('#list-users[data-total-count="1"] a[role="row"]')
-              .wait('#clickable-viewcurrentloans')
-              .click('#clickable-viewcurrentloans')
-              .wait('#list-loanshistory:not([data-total-count="0"])')
-              .wait(findBarcodeCell, barcode)
-              .then(done)
-              .catch(done);
-          });
-        });
-
-        describe('Renew success', () => {
-          it('should renew the loan and succeed', (done) => {
-            nightmare
-              .wait('#list-loanshistory')
-              .wait(findBarcodeCell, barcode)
-              .evaluate(tickRenewCheckbox, barcode)
-              .then(() => {
-                nightmare
-                  .wait('#renew-all')
-                  .click('#renew-all')
-                  .wait('div[class^="calloutBase"]')
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-        });
-
-        describe('Renew failure', () => {
-          it('should renew the loan second time and hit the renewal limit', (done) => {
-            nightmare
-              .wait('#list-loanshistory')
-              .wait(findBarcodeCell, barcode)
-              .evaluate(tickRenewCheckbox, barcode)
-              .then(() => {
-                nightmare
-                  .wait('#renew-all')
-                  .click('#renew-all')
-                  .wait('#bulk-renewal-modal')
-                  .wait(333)
-                  .evaluate(() => {
-                    const errorMsg = document.querySelectorAll('#bulk-renewal-modal [role="gridcell"]')[0].textContent;
-                    if (errorMsg === null) {
-                      throw new Error('Should throw an error as the renewalLimit is reached');
-                    } else if (!errorMsg.match('Item not renewed:loan at maximum renewal number')) {
-                      throw new Error('Expected only the renewal failure error message');
-                    }
-                  }, policyName)
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-        });
-
-        describe('Renew failure', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
-
-          it('should reach "loan policy settings" page', (done) => {
-            nightmare
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/loan-policies"]')
-              .click('a[href="/settings/circulation/loan-policies"]')
-              .then(done)
-              .catch(done);
-          });
-
-          it('edit loan policy to renew from system date', (done) => {
-            nightmare
-              .wait('div.hasEntries')
-              .evaluate((pn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                )
-                  .findIndex(e => e.textContent === pn);
-
-                if (index === -1) {
-                  throw new Error(`Could not find the loan policy ${pn} to edit`);
-                }
-
-                // CSS selectors are 1-based, which is just totally awesome.
-                return index + 1;
-              }, policyName)
-              .then((entryIndex) => {
-                nightmare
-                  .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .wait('#clickable-edit-item')
-                  .click('#clickable-edit-item')
-                  .wait('#input_allowed_renewals')
-                  .type('#input_allowed_renewals', 2)
-                  .wait('#select_renew_from')
-                  .select('#select_renew_from', 'SYSTEM_DATE')
-                  .wait('#footer-save-entity')
-                  .click('#footer-save-entity')
-                  .wait(1000)
-                  .evaluate(() => {
-                    const sel = document.querySelector('div[class^="textfieldError"]');
-                    if (sel) {
-                      throw new Error(sel.textContent);
-                    }
-                  })
-                  .wait(() => !document.querySelector('#footer-save-entity'))
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-
-          it('should navigate to users', (done) => {
-            helpers.clickApp(nightmare, done, 'users', 1000);
-          });
-
-          it('should fail the renewal', (done) => {
-            nightmare
-              .wait(findBarcodeCell, barcode)
-              .evaluate(tickRenewCheckbox, barcode)
-              .then(() => {
-                nightmare
-                  .wait('#renew-all')
-                  .click('#renew-all')
-                  .wait('#bulk-renewal-modal')
-                  .wait(1000)
-                  .evaluate(() => {
-                    const expectedMessage = 'Item not renewed:renewal would not change the due date';
-                    const errorMsg = document.querySelectorAll('#bulk-renewal-modal div[role="gridcell"]')[0].textContent;
-                    if (errorMsg === null) {
-                      throw new Error('Should throw an error as the renewalLimit is reached');
-                    } else if (!errorMsg.match(expectedMessage)) {
-                      throw new Error(`Expected "${expectedMessage}"; got "${errorMsg}"`);
-                    }
-                  })
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-        });
-
-        describe('Create fixed due date schedule', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
-
-          it('should create a new fixed due date schedule', (done) => {
-            nightmare
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/fixed-due-date-schedules"]')
-              .click('a[href="/settings/circulation/fixed-due-date-schedules"]')
-              .wait('#clickable-create-entry')
-              .click('#clickable-create-entry')
-              .wait('#input_schedule_name')
-              .type('#input_schedule_name', scheduleName)
-              .wait('input[name="schedules[0].from"]')
-              .insert('input[name="schedules[0].from"]', tomorrowValue)
-              .wait('input[name="schedules[0].to"]')
-              .insert('input[name="schedules[0].to"]', dayAfterValue)
-              .wait('input[name="schedules[0].due"]')
-              .insert('input[name="schedules[0].due"]', nextMonthValue)
-              .wait('#clickable-save-fixedDueDateSchedule')
-              .click('#clickable-save-fixedDueDateSchedule')
               .wait(1000)
               .evaluate(() => {
                 const sel = document.querySelector('div[class^="feedbackError"]');
@@ -448,164 +368,94 @@ module.exports.test = (uiTestCtx) => {
                   throw new Error(sel.textContent);
                 }
               })
+              .wait(() => !document.querySelector('#footer-save-entity'))
               .then(done)
               .catch(done);
-          });
-        });
+          })
+          .catch(done);
+      });
+    });
 
-        describe('Assign fixed due date schedule to loan policy', () => {
-          it(`assign the fixed due date schedule (${scheduleName}) to the loan policy`, (done) => {
+    describe('Renew failure', () => {
+      it('should navigate to users', (done) => {
+        helpers.clickApp(nightmare, done, 'users', 555);
+      });
+
+      it('Renewal should fail as renewal date falls outside of the date ranges', (done) => {
+        nightmare
+          .wait(findBarcodeCell, barcode)
+          .evaluate(tickRenewCheckbox, barcode)
+          .then(() => {
             nightmare
-              .wait('a[href="/settings/circulation/loan-policies"]')
-              .click('a[href="/settings/circulation/loan-policies"]')
-              .wait('div.hasEntries')
-              .evaluate((pn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                )
-                  .findIndex(e => e.textContent === pn);
-
-                if (index === -1) {
-                  throw new Error(`Could not find the loan policy ${pn} to edit`);
+              .wait('#renew-all')
+              .click('#renew-all')
+              .wait('#bulk-renewal-modal')
+              .evaluate(() => {
+                const errorMsg = document.querySelectorAll('#bulk-renewal-modal div[role="gridcell"]')[0].textContent;
+                if (errorMsg === null) {
+                  throw new Error('Should throw an error as the renewalLimit is reached');
+                } else if (!errorMsg.match('Item not renewed:renewal date falls outside of date ranges in fixed loan policy')) {
+                  throw new Error('Expected Loan cannot be renewed because: renewal date falls outside of the date ranges in the loan policy error message');
                 }
-
-                // CSS selectors are 1-based, which is just totally awesome.
-                return index + 1;
-              }, policyName)
-              .then((entryIndex) => {
-                nightmare
-                  .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .wait('#clickable-edit-item')
-                  .click('#clickable-edit-item')
-                  .wait('#input_loan_profile')
-                  .type('#input_loan_profile', 'fi')
-                  .wait('#input_loansPolicy_fixedDueDateSchedule')
-                  .type('#input_loansPolicy_fixedDueDateSchedule', scheduleName)
-                  .wait('select[name="loansPolicy.closedLibraryDueDateManagementId"]')
-                  .type('select[name="loansPolicy.closedLibraryDueDateManagementId"]', 'keep')
-                  .wait('#footer-save-entity')
-                  .click('#footer-save-entity')
-                  .wait(1000)
-                  .evaluate(() => {
-                    const sel = document.querySelector('div[class^="feedbackError"]');
-                    if (sel) {
-                      throw new Error(sel.textContent);
-                    }
-                  })
-                  .wait(() => !document.querySelector('#footer-save-entity'))
-                  .then(done)
-                  .catch(done);
               })
-              .catch(done);
-          });
-        });
-
-        describe('Renew failure', () => {
-          it('should navigate to users', (done) => {
-            helpers.clickApp(nightmare, done, 'users', 555);
-          });
-
-          it('Renewal should fail as renewal date falls outside of the date ranges', (done) => {
-            nightmare
-              .wait(findBarcodeCell, barcode)
-              .evaluate(tickRenewCheckbox, barcode)
-              .then(() => {
-                nightmare
-                  .wait('#renew-all')
-                  .click('#renew-all')
-                  .wait('#bulk-renewal-modal')
-                  .evaluate(() => {
-                    const errorMsg = document.querySelectorAll('#bulk-renewal-modal div[role="gridcell"]')[0].textContent;
-                    if (errorMsg === null) {
-                      throw new Error('Should throw an error as the renewalLimit is reached');
-                    } else if (!errorMsg.match('Item not renewed:renewal date falls outside of date ranges in fixed loan policy')) {
-                      throw new Error('Expected Loan cannot be renewed because: renewal date falls outside of the date ranges in the loan policy error message');
-                    }
-                  })
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-        });
-
-        describe('Check in', () => {
-          it('should navigate to checkin', (done) => {
-            helpers.clickApp(nightmare, done, 'checkin');
-          });
-
-          it(`should check in ${barcode}`, (done) => {
-            nightmare
-              .wait('#input-item-barcode')
-              .insert('#input-item-barcode', barcode)
-              .wait('#clickable-add-item')
-              .click('#clickable-add-item')
-              .wait('#list-items-checked-in')
-              .wait(bc => {
-                return !!(Array.from(document.querySelectorAll('#list-items-checked-in div[role="gridcell"]'))
-                  .find(e => e.textContent === `${bc}`));
-              }, barcode)
               .then(done)
               .catch(done);
-          });
+          })
+          .catch(done);
+      });
+    });
+
+    describe('Check in', () => {
+      it('should navigate to checkin', (done) => {
+        helpers.clickApp(nightmare, done, 'checkin');
+      });
+
+      it(`should check in ${barcode}`, (done) => {
+        nightmare
+          .wait('#input-item-barcode')
+          .insert('#input-item-barcode', barcode)
+          .wait('#clickable-add-item')
+          .click('#clickable-add-item')
+          .wait('#list-items-checked-in')
+          .wait(bc => {
+            return !!(Array.from(document.querySelectorAll('#list-items-checked-in div[role="gridcell"]'))
+              .find(e => e.textContent === `${bc}`));
+          }, barcode)
+          .then(done)
+          .catch(done);
+      });
+    });
+
+    describe('restore settings', () => {
+      describe('it should restore settings', () => {
+        it('should navigate to settings', (done) => {
+          helpers.clickSettings(nightmare, done);
         });
 
-        describe('Restore the circulation rules', () => {
-          it('should navigate to settings', (done) => {
-            helpers.clickSettings(nightmare, done);
-          });
-
-          it('should restore the circulation rules', (done) => {
-            helpers.setCirculationRules(nightmare, loanRules)
-              .then(() => done())
-              .catch(done);
-          });
+        it('should restore the circulation rules', (done) => {
+          helpers.setCirculationRules(nightmare, initialRules)
+            .then(() => done())
+            .catch(done);
         });
 
-        describe('Delete loan policy', () => {
-          it('should delete the loan policy', (done) => {
-            nightmare
-              .click(config.select.settings)
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/loan-policies"]')
-              .click('a[href="/settings/circulation/loan-policies"]')
-              .wait('div.hasEntries')
-              .wait((pn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                ).findIndex(e => e.textContent === pn);
-                return index >= 0;
-              }, policyName)
-              .evaluate((pn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                ).findIndex(e => e.textContent === pn);
-                if (index === -1) {
-                  throw new Error(`Could not find the loan policy ${pn} to delete`);
-                }
-                // CSS selectors are 1-based, which is just totally awesome.
-                return index + 1;
-              }, policyName)
-              .then((entryIndex) => {
-                nightmare
-                  .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .wait('#dropdown-clickable-delete-item')
-                  .click('#dropdown-clickable-delete-item')
-                  .wait('#clickable-delete-item-confirmation-confirm')
-                  .click('#clickable-delete-item-confirmation-confirm')
-                  .wait((pn) => {
-                    return Array.from(
-                      document.querySelectorAll('#OverlayContainer div[class^="calloutBase"]')
-                    ).findIndex(e => e.textContent === `The Loan policy ${pn} was successfully deleted.`) >= 0;
-                  }, policyName)
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
+        describe('remove Overdue Fine Policy', function foo() {
+          helpers.removeOverdueFinePolicy(nightmare, overdueFinePolicyName);
+        });
+
+        describe('remove Lost Item Fee Policy', function foo() {
+          helpers.removeLostItemFeePolicy(nightmare, lostItemFeePolicyName);
+        });
+
+        describe('remove Notice Policy', function foo() {
+          helpers.removeNoticePolicy(nightmare, noticePolicyName);
+        });
+
+        describe('remove loan policy', () => {
+          helpers.removeLoanPolicy(nightmare, policyName);
+        });
+
+        describe('remove request policy', () => {
+          helpers.removeRequestPolicy(nightmare, requestPolicyName);
         });
 
         describe('Delete fixed due date schedule', () => {
@@ -657,107 +507,13 @@ module.exports.test = (uiTestCtx) => {
               .catch(done);
           });
         });
+      });
+    });
 
-        describe('Delete request policy', () => {
-          it('should delete the request policy', (done) => {
-            nightmare
-              .click(config.select.settings)
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/request-policies"]')
-              .click('a[href="/settings/circulation/request-policies"]')
-              .wait('div.hasEntries')
-              .wait((rpn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                ).findIndex(e => e.textContent === rpn);
-                return index >= 0;
-              }, requestPolicyName)
-              .evaluate((rpn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                ).findIndex(e => e.textContent === rpn);
-                if (index === -1) {
-                  throw new Error(`Could not find the request policy ${rpn} to delete`);
-                }
-                // CSS selectors are 1-based, which is just totally awesome.
-                return index + 1;
-              }, requestPolicyName)
-              .then((entryIndex) => {
-                nightmare
-                  .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .wait('#general')
-                  .wait('#dropdown-clickable-delete-item')
-                  .click('#dropdown-clickable-delete-item')
-                  .wait('#clickable-delete-item-confirmation-confirm')
-                  .click('#clickable-delete-item-confirmation-confirm')
-                  .wait((rpn) => {
-                    return Array.from(
-                      document.querySelectorAll('#OverlayContainer div[class^="calloutBase"]')
-                    ).findIndex(e => e.textContent === `The Request policy ${rpn} was successfully deleted.`) >= 0;
-                  }, requestPolicyName)
-                  .wait(() => !document.querySelector('#OverlayContainer div[class^="calloutBase"]'))
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-        });
-
-        describe('Delete notice policy', () => {
-          it('should delete the notice policy', (done) => {
-            nightmare
-              .click(config.select.settings)
-              .wait('a[href="/settings/circulation"]')
-              .click('a[href="/settings/circulation"]')
-              .wait('a[href="/settings/circulation/notice-policies"]')
-              .click('a[href="/settings/circulation/notice-policies"]')
-              .wait('div.hasEntries')
-              .wait((npn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                ).findIndex(e => e.textContent === npn);
-                return index >= 0;
-              }, noticePolicyName)
-              .evaluate((npn) => {
-                const index = Array.from(
-                  document.querySelectorAll('#ModuleContainer div.hasEntries a div')
-                ).findIndex(e => e.textContent === npn);
-                if (index === -1) {
-                  throw new Error(`Could not find the notice policy${npn} to delete`);
-                }
-                // CSS selectors are 1-based, which is just totally awesome.
-                return index + 1;
-              }, noticePolicyName)
-              .then((entryIndex) => {
-                nightmare
-                  .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                  .wait('#generalInformation')
-                  .wait('#dropdown-clickable-delete-item')
-                  .click('#dropdown-clickable-delete-item')
-                  .wait('#clickable-delete-item-confirmation-confirm')
-                  .click('#clickable-delete-item-confirmation-confirm')
-                  .wait((npn) => {
-                    return Array.from(
-                      document.querySelectorAll('#OverlayContainer div[class^="calloutBase"]')
-                    ).findIndex(e => e.textContent === `The Patron notice policy ${npn} was successfully deleted.`) >= 0;
-                  }, noticePolicyName)
-                  .wait(() => !document.querySelector('#OverlayContainer div[class^="calloutBase"]'))
-                  .then(done)
-                  .catch(done);
-              })
-              .catch(done);
-          });
-        });
-
-        describe('logout', () => {
-          it('should logout', (done) => {
-            helpers.logout(nightmare, config, done);
-          });
-        });
-      }
-    );
+    describe('logout', () => {
+      it('should logout', (done) => {
+        helpers.logout(nightmare, config, done);
+      });
+    });
   });
 };

--- a/test/ui-testing/many-items.js
+++ b/test/ui-testing/many-items.js
@@ -11,6 +11,11 @@ module.exports.test = (uiTestCtx) => {
     let userBarcode = '';
     const count = 21;
 
+    let initialRules = '';
+    const overdueFinePolicyName = `test-overdue-fine-policy-${Math.floor(Math.random() * 10000)}`;
+    const lostItemFeePolicyName = `test-lost-item-policy-${Math.floor(Math.random() * 10000)}`;
+    const noticePolicyName = `test-notice-policy-${Math.floor(Math.random() * 10000)}`;
+
     it(`should login as ${config.username}/${config.password}`, (done) => {
       helpers.login(nightmare, config, done);
     });
@@ -35,6 +40,40 @@ module.exports.test = (uiTestCtx) => {
       });
     });
 
+    describe('it should configure settings', () => {
+      it('should navigate to settings', (done) => {
+        helpers.clickSettings(nightmare, done);
+      });
+
+      it('should configure checkout for barcode and username', (done) => {
+        helpers.circSettingsCheckoutByBarcodeAndUsername(nightmare, config, done);
+      });
+
+      describe('addOverdueFinePolicy', function foo() {
+        helpers.addOverdueFinePolicy(nightmare, overdueFinePolicyName);
+      });
+
+      describe('addLostItemFeePolicy', function foo() {
+        helpers.addLostItemFeePolicy(nightmare, lostItemFeePolicyName, 10, 'm');
+      });
+
+      describe('addNoticePolicy', function foo() {
+        helpers.addNoticePolicy(nightmare, noticePolicyName);
+      });
+
+      describe('it should configure circulation rules', function foo() {
+        it('set new rules circulation rules', (done) => {
+          const rules = `priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n ${noticePolicyName} o ${overdueFinePolicyName} i ${lostItemFeePolicyName} \nm book: l example-loan-policy r allow-all n ${noticePolicyName} o ${overdueFinePolicyName} i ${lostItemFeePolicyName} `;
+          helpers.setCirculationRules(nightmare, rules)
+            .then(oldRules => {
+              initialRules = oldRules;
+            })
+            .then(done)
+            .catch(done);
+        });
+      });
+    });
+
     describe('checkout items', () => {
       it('should navigate to checkout', (done) => {
         helpers.clickApp(nightmare, done, 'checkout', 1000);
@@ -42,6 +81,30 @@ module.exports.test = (uiTestCtx) => {
 
       it(`should checkout ${count} items`, (done) => {
         helpers.checkoutList(nightmare, done, barcodes, userBarcode);
+      });
+    });
+
+    describe('it should restore settings', () => {
+      it('should navigate to settings', (done) => {
+        helpers.clickSettings(nightmare, done);
+      });
+
+      it('should restore the circulation rules', (done) => {
+        helpers.setCirculationRules(nightmare, initialRules)
+          .then(() => done())
+          .catch(done);
+      });
+
+      describe('remove Overdue Fine Policy', function foo() {
+        helpers.removeOverdueFinePolicy(nightmare, overdueFinePolicyName);
+      });
+
+      describe('remove Lost Item Fee Policy', function foo() {
+        helpers.removeLostItemFeePolicy(nightmare, lostItemFeePolicyName);
+      });
+
+      describe('remove Notice Policy', function foo() {
+        helpers.removeNoticePolicy(nightmare, noticePolicyName);
       });
     });
 

--- a/test/ui-testing/new-proxy.js
+++ b/test/ui-testing/new-proxy.js
@@ -1,112 +1,176 @@
 module.exports.test = function foo(uiTestCtx) {
   describe('User proxies ("new-proxy")', function bar() {
-    const { config, helpers: { login, clickApp, findActiveUserBarcode, logout } } = uiTestCtx;
+    const { config, helpers } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
     this.timeout(Number(config.test_timeout));
     let sponsorId = '';
     let proxyId = '';
+    let initialRules = '';
+    const overdueFinePolicyName = `test-overdue-fine-policy-${Math.floor(Math.random() * 10000)}`;
+    const lostItemFeePolicyName = `test-lost-item-policy-${Math.floor(Math.random() * 10000)}`;
+    const noticePolicyName = `test-notice-policy-${Math.floor(Math.random() * 10000)}`;
 
     describe('Login > Find user two users > Add proxy to user 1 > Delete sponsor in user 2 > Logout\n', () => {
       before((done) => {
-        login(nightmare, config, done); // logs in with the default admin credentials
+        helpers.login(nightmare, config, done); // logs in with the default admin credentials
       });
 
       after((done) => {
-        logout(nightmare, config, done);
+        helpers.logout(nightmare, config, done);
       });
 
-      it('should navigate to users', (done) => {
-        clickApp(nightmare, done, 'users');
-      });
+      describe('it should configure settings', () => {
+        it('should navigate to settings', (done) => {
+          helpers.clickSettings(nightmare, done);
+        });
 
-      it('should find an active user (sponsor)', (done) => {
-        findActiveUserBarcode(nightmare, 'faculty')
-          .then(bc => {
-            done();
-            console.log(`\t    Found sponsor ${bc}`);
-            sponsorId = bc;
-          })
-          .catch(done);
-      });
+        it('should configure checkout for barcode and username', (done) => {
+          helpers.circSettingsCheckoutByBarcodeAndUsername(nightmare, config, done);
+        });
 
-      it('should add a proxy to sponsor', (done) => {
-        const selector = '#list-plugin-find-user [role="row"][aria-rowindex="2"] [role="gridcell"]:nth-child(3)';
-        nightmare
-          .wait('#input-user-search')
-          .type('#input-user-search', '0')
-          .wait('#clickable-reset-all')
-          .click('#clickable-reset-all')
-          .wait('[class^="noResultsMessage"]')
-          .insert('#input-user-search', sponsorId)
-          .wait('#submit-user-search')
-          .click('#submit-user-search')
-          .wait('#list-users[data-total-count="1"]')
-          .wait('#list-users a[role="row"]')
-          .click('#list-users a[role="row"]')
-          .wait('#clickable-edituser')
-          .click('#clickable-edituser')
-          .wait('#accordion-toggle-button-proxyAccordion')
-          .click('#accordion-toggle-button-proxyAccordion')
-          .wait('#proxyAccordion #clickable-plugin-find-proxy')
-          .click('#proxyAccordion #clickable-plugin-find-proxy')
-          .wait('#OverlayContainer input[name=query]')
-          // .insert('#OverlayContainer input[name=query]', proxyId)
-          // .wait('#OverlayContainer button[type=submit]')
-          // .click('#OverlayContainer button[type=submit]')
-          .wait('#OverlayContainer #clickable-filter-active-active')
-          .click('#OverlayContainer #clickable-filter-active-active')
-          .wait('#OverlayContainer #clickable-filter-pg-undergrad')
-          .click('#OverlayContainer #clickable-filter-pg-undergrad')
-          .wait(() => !document.querySelectorAll('#OverlayContainer [class^="noResultsMessage"]').length)
-          .wait('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
-          .evaluate((s) => {
-            return document.querySelector(s).textContent;
-          }, selector)
-          .then(barcode => {
-            nightmare
-              .wait('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
-              .click('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
-              .wait('#clickable-save')
-              .click('#clickable-save')
-              .wait(() => !document.querySelector('#form-user'))
+        describe('addOverdueFinePolicy', () => {
+          helpers.addOverdueFinePolicy(nightmare, overdueFinePolicyName);
+        });
+
+        describe('addLostItemFeePolicy', () => {
+          helpers.addLostItemFeePolicy(nightmare, lostItemFeePolicyName, 10, 'm');
+        });
+
+        describe('addNoticePolicy', () => {
+          helpers.addNoticePolicy(nightmare, noticePolicyName);
+        });
+
+        describe('it should configure circulation rules', () => {
+          it('set new rules circulation rules', (done) => {
+            const rules = `priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n ${noticePolicyName} o ${overdueFinePolicyName} i ${lostItemFeePolicyName} \nm book: l example-loan-policy r allow-all n ${noticePolicyName} o ${overdueFinePolicyName} i ${lostItemFeePolicyName} `;
+            helpers.setCirculationRules(nightmare, rules)
+              .then(oldRules => {
+                initialRules = oldRules;
+              })
               .then(done)
               .catch(done);
-            proxyId = barcode;
-          })
-          .catch(done);
+          });
+        });
       });
 
-      it('should delete a sponsor of user 2', (done) => {
-        nightmare
-          // put some junk in the search field to get the reset button
-          // so we can click it and be sure the field is clear before
-          // entering new data.
-          .wait('#input-user-search')
-          .type('#input-user-search', '0')
-          .wait('#clickable-reset-all')
-          .click('#clickable-reset-all')
-          .wait('[class^="noResultsMessage"]')
-          .insert('#input-user-search', proxyId)
-          .wait('#submit-user-search')
-          .click('#submit-user-search')
-          .wait('#list-users[data-total-count="1"]')
-          .wait('#list-users a[role="row"]')
-          .click('#list-users a[role="row"]')
-          .wait('#accordion-toggle-button-proxySection')
-          .wait('#clickable-edituser')
-          .click('#clickable-edituser')
-          .wait('#accordion-toggle-button-proxyAccordion')
-          .click('#accordion-toggle-button-proxyAccordion')
-          .wait('#proxyAccordion div[class*=sectionActions] button')
-          .click('#proxyAccordion div[class*=sectionActions] button')
-          .wait('#OverlayContainer [role="dialog"]')
-          .wait('#clickable-deletesponsors-confirmation-confirm')
-          .click('#clickable-deletesponsors-confirmation-confirm')
-          .wait('#clickable-save')
-          .click('#clickable-save')
-          .then(done)
-          .catch(done);
+      describe('test proxies', () => {
+        it('should navigate to users', (done) => {
+          helpers.clickApp(nightmare, done, 'users');
+        });
+
+        it('should find an active user (sponsor)', (done) => {
+          helpers.findActiveUserBarcode(nightmare, 'faculty')
+            .then(bc => {
+              done();
+              console.log(`\t    Found sponsor ${bc}`);
+              sponsorId = bc;
+            })
+            .catch(done);
+        });
+
+        it('should add a proxy to sponsor', (done) => {
+          const selector = '#list-plugin-find-user [role="row"][aria-rowindex="2"] [role="gridcell"]:nth-child(3)';
+          nightmare
+            .wait('#input-user-search')
+            .type('#input-user-search', '0')
+            .wait('#clickable-reset-all')
+            .click('#clickable-reset-all')
+            .wait('[class^="noResultsMessage"]')
+            .insert('#input-user-search', sponsorId)
+            .wait('#submit-user-search')
+            .click('#submit-user-search')
+            .wait('#list-users[data-total-count="1"]')
+            .wait('#list-users a[role="row"]')
+            .click('#list-users a[role="row"]')
+            .wait('#clickable-edituser')
+            .click('#clickable-edituser')
+            .wait('#accordion-toggle-button-proxyAccordion')
+            .click('#accordion-toggle-button-proxyAccordion')
+            .wait('#proxyAccordion #clickable-plugin-find-proxy')
+            .click('#proxyAccordion #clickable-plugin-find-proxy')
+            .wait('#OverlayContainer input[name=query]')
+            // .insert('#OverlayContainer input[name=query]', proxyId)
+            // .wait('#OverlayContainer button[type=submit]')
+            // .click('#OverlayContainer button[type=submit]')
+            .wait('#OverlayContainer #clickable-filter-active-active')
+            .click('#OverlayContainer #clickable-filter-active-active')
+            .wait('#OverlayContainer #clickable-filter-pg-undergrad')
+            .click('#OverlayContainer #clickable-filter-pg-undergrad')
+            .wait(() => !document.querySelectorAll('#OverlayContainer [class^="noResultsMessage"]').length)
+            .wait('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
+            .evaluate((s) => {
+              return document.querySelector(s).textContent;
+            }, selector)
+            .then(barcode => {
+              nightmare
+                .wait('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
+                .click('#list-plugin-find-user [role="row"][aria-rowindex="2"]')
+                .wait('#clickable-save')
+                .click('#clickable-save')
+                .wait(() => !document.querySelector('#form-user'))
+                .then(done)
+                .catch(done);
+              proxyId = barcode;
+            })
+            .catch(done);
+        });
+
+        it('should delete a sponsor of user 2', (done) => {
+          nightmare
+            // put some junk in the search field to get the reset button
+            // so we can click it and be sure the field is clear before
+            // entering new data.
+            .wait('#input-user-search')
+            .type('#input-user-search', '0')
+            .wait('#clickable-reset-all')
+            .click('#clickable-reset-all')
+            .wait('[class^="noResultsMessage"]')
+            .insert('#input-user-search', proxyId)
+            .wait('#submit-user-search')
+            .click('#submit-user-search')
+            .wait('#list-users[data-total-count="1"]')
+            .wait('#list-users a[role="row"]')
+            .click('#list-users a[role="row"]')
+            .wait('#accordion-toggle-button-proxySection')
+            .wait('#clickable-edituser')
+            .click('#clickable-edituser')
+            .wait('#accordion-toggle-button-proxyAccordion')
+            .click('#accordion-toggle-button-proxyAccordion')
+            .wait('#proxyAccordion div[class*=sectionActions] button')
+            .click('#proxyAccordion div[class*=sectionActions] button')
+            .wait('#OverlayContainer [role="dialog"]')
+            .wait('#clickable-deletesponsors-confirmation-confirm')
+            .click('#clickable-deletesponsors-confirmation-confirm')
+            .wait('#clickable-save')
+            .click('#clickable-save')
+            .then(done)
+            .catch(done);
+        });
+      });
+
+      describe('it should restore settings', () => {
+        it('should navigate to settings', (done) => {
+          helpers.clickSettings(nightmare, done);
+        });
+
+        it('should restore the circulation rules', (done) => {
+          helpers.setCirculationRules(nightmare, initialRules)
+            .then(() => done())
+            .catch(done);
+        });
+
+        describe('remove Overdue Fine Policy', () => {
+          helpers.removeOverdueFinePolicy(nightmare, overdueFinePolicyName);
+        });
+
+        describe('remove Lost Item Fee Policy', () => {
+          helpers.removeLostItemFeePolicy(nightmare, lostItemFeePolicyName);
+        });
+
+        describe('remove Notice Policy', () => {
+          helpers.removeNoticePolicy(nightmare, noticePolicyName);
+        });
       });
     });
   });

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -1,6 +1,6 @@
 module.exports.test = function uiTest(uiTestCtx) {
   describe('New request ("new-request")', function modTest() {
-    const { config, helpers: { login, clickApp, clickSettings, createInventory, setCirculationRules, checkout, logout } } = uiTestCtx;
+    const { config, helpers } = uiTestCtx;
     const nightmare = new Nightmare(config.nightmare);
 
     const servicePoint = 'Circ Desk 1';
@@ -13,153 +13,186 @@ module.exports.test = function uiTest(uiTestCtx) {
       const nextMonthValue = new Date().valueOf() + 2419200000;
       const nextMonth = new Date(nextMonthValue).toLocaleDateString('en-US');
       before((done) => {
-        login(nightmare, config, done); // logs in with the default admin credentials
+        helpers.login(nightmare, config, done); // logs in with the default admin credentials
       });
 
       after((done) => {
-        logout(nightmare, config, done);
+        helpers.logout(nightmare, config, done);
       });
 
       let initialRules = '';
+      const overdueFinePolicyName = `test-overdue-fine-policy-${Math.floor(Math.random() * 10000)}`;
+      const lostItemFeePolicyName = `test-lost-item-policy-${Math.floor(Math.random() * 10000)}`;
+      const noticePolicyName = `test-notice-policy-${Math.floor(Math.random() * 10000)}`;
 
-      it('should navigate to settings', (done) => {
-        clickSettings(nightmare, done);
+      describe('configure settings', () => {
+        it('should navigate to settings', (done) => {
+          helpers.clickSettings(nightmare, done);
+        });
+
+        it('should configure default circulation rules', (done) => {
+          const newRules = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy o overdue-test i lost-item-test\nm book: l example-loan-policy r allow-all n alternate-notice-policy o overdue-test i lost-item-test';
+          helpers.setCirculationRules(nightmare, newRules)
+            .then(oldRules => {
+              initialRules = oldRules;
+            })
+            .then(done)
+            .catch(done);
+        });
+
+        describe('addOverdueFinePolicy', function foo() {
+          helpers.addOverdueFinePolicy(nightmare, overdueFinePolicyName);
+        });
+
+        describe('addLostItemFeePolicy', function foo() {
+          helpers.addLostItemFeePolicy(nightmare, lostItemFeePolicyName, 10, 'm');
+        });
+
+        describe('addNoticePolicy', function foo() {
+          helpers.addNoticePolicy(nightmare, noticePolicyName);
+        });
       });
 
-      it('should configure default circulation rules', (done) => {
-        const newRules = 'priority: t, s, c, b, a, m, g\nfallback-policy: l one-hour r hold-only n basic-notice-policy o overdue-test\nm book: l example-loan-policy r allow-all n alternate-notice-policy o overdue-test';
-        setCirculationRules(nightmare, newRules)
-          .then(oldRules => {
-            initialRules = oldRules;
-          })
-          .then(done)
-          .catch(done);
+      describe('exercise requests', () => {
+        it('should navigate to users', (done) => {
+          helpers.clickApp(nightmare, done, 'users', 1000);
+        });
+
+        it('should find an active user barcode for checkout', (done) => {
+          const listitem = '#list-users [aria-rowindex="4"] [role=gridcell]:nth-of-type(3)';
+          nightmare
+            .wait('#clickable-filter-active-active')
+            .click('#clickable-filter-active-active')
+            .wait('#list-users[data-total-count]')
+            .evaluate(() => {
+              return document.querySelector('#list-users').getAttribute('data-total-count');
+            })
+            .then((count) => {
+              nightmare
+                .wait('#clickable-filter-pg-undergrad')
+                .click('#clickable-filter-pg-undergrad')
+                .wait(`#list-users:not([data-total-count="${count}"])`)
+                .wait(listitem)
+                .evaluate((bcode) => {
+                  return document.querySelector(bcode).textContent;
+                }, listitem)
+                .then((result) => {
+                  done();
+                  userbc = result;
+                  console.log(`        Found ${userbc}`);
+                })
+                .catch(done);
+            })
+            .catch(done);
+        });
+
+        it('should find an active user barcode for request', (done) => {
+          const listitem = '#list-users [aria-rowIndex="5"] [role=gridcell]:nth-of-type(3)';
+          nightmare
+            .evaluate((bcode) => {
+              return document.querySelector(bcode).textContent;
+            }, listitem)
+            .then((result) => {
+              done();
+              userbcRequestor = result;
+              console.log(`        Found ${userbcRequestor}`);
+            })
+            .catch(done);
+        });
+
+        const itembc = helpers.createInventory(nightmare, config, 'Request title');
+
+        it('should navigate to checkout', (done) => {
+          helpers.clickApp(nightmare, done, 'checkout', 1000);
+        });
+
+        it('should check out newly created item', (done) => {
+          helpers.checkout(nightmare, done, itembc, userbc);
+        });
+
+        it('should navigate to requests', (done) => {
+          helpers.clickApp(nightmare, done, 'requests', 1000);
+        });
+
+        it('should add a new "Hold" request', (done) => {
+          nightmare
+            .wait('#clickable-newrequest')
+            .click('#clickable-newrequest')
+            .insert('input[name="item.barcode"]', itembc)
+            .wait('#clickable-select-item')
+            .click('#clickable-select-item')
+            .wait('#section-item-info a[href^="/inventory/view/"]')
+            .wait('select[name="requestType"]')
+            .select('select[name="requestType"]', 'Hold')
+            .wait('input[name="requester.barcode"]')
+            .insert('input[name="requester.barcode"]', userbcRequestor)
+            .wait('#clickable-select-requester')
+            .click('#clickable-select-requester')
+            .wait('#section-requester-info a[href^="/users/view/"]')
+            .wait('select[name="fulfilmentPreference"]')
+            .select('select[name="fulfilmentPreference"]', 'Hold Shelf')
+            .wait('input[name="requestExpirationDate"]')
+            .insert('input[name="requestExpirationDate"]', nextMonth)
+
+            .evaluate((servicePointName) => {
+              const node = Array.from(
+                document.querySelectorAll('select[name="pickupServicePointId"] option')
+              ).find(e => e.text.startsWith(servicePointName));
+              if (node) {
+                return node.value;
+              }
+
+              throw new Error(`Could not find the ID for the servicePoint ${servicePointName} ${node}`);
+            }, servicePoint)
+            .then((servicePointId) => {
+              nightmare
+                .select('select[name="pickupServicePointId"]', servicePointId)
+                .wait('input[name="requestExpirationDate"]')
+                .insert('input[name="requestExpirationDate"]', nextMonth)
+                .wait('#clickable-save-request')
+                .click('#clickable-save-request')
+                .wait(() => !document.querySelector('#clickable-save-request'))
+                .wait(3333)
+                .then(done)
+                .catch(done);
+            })
+            .catch(done);
+        });
+
+        it('should find new request in requests list', (done) => {
+          nightmare
+            .wait('#input-request-search')
+            .insert('#input-request-search', itembc)
+            .wait('button[type="submit"]')
+            .click('button[type="submit"]')
+            .wait('#list-requests[data-total-count="1"]')
+            .then(done)
+            .catch(done);
+        });
       });
 
-      it('should navigate to users', (done) => {
-        clickApp(nightmare, done, 'users', 1000);
-      });
+      describe('restore settings', () => {
+        it('should navigate to settings', (done) => {
+          helpers.clickSettings(nightmare, done);
+        });
 
-      it('should find an active user barcode for checkout', (done) => {
-        const listitem = '#list-users [aria-rowindex="4"] [role=gridcell]:nth-of-type(3)';
-        nightmare
-          .wait('#clickable-filter-active-active')
-          .click('#clickable-filter-active-active')
-          .wait('#list-users[data-total-count]')
-          .evaluate(() => {
-            return document.querySelector('#list-users').getAttribute('data-total-count');
-          })
-          .then((count) => {
-            nightmare
-              .wait('#clickable-filter-pg-undergrad')
-              .click('#clickable-filter-pg-undergrad')
-              .wait(`#list-users:not([data-total-count="${count}"])`)
-              .wait(listitem)
-              .evaluate((bcode) => {
-                return document.querySelector(bcode).textContent;
-              }, listitem)
-              .then((result) => {
-                done();
-                userbc = result;
-                console.log(`        Found ${userbc}`);
-              })
-              .catch(done);
-          })
-          .catch(done);
-      });
+        it('should restore initial circulation rules', (done) => {
+          helpers.setCirculationRules(nightmare, initialRules)
+            .then(() => done())
+            .catch(done);
+        });
 
-      it('should find an active user barcode for request', (done) => {
-        const listitem = '#list-users [aria-rowIndex="5"] [role=gridcell]:nth-of-type(3)';
-        nightmare
-          .evaluate((bcode) => {
-            return document.querySelector(bcode).textContent;
-          }, listitem)
-          .then((result) => {
-            done();
-            userbcRequestor = result;
-            console.log(`        Found ${userbcRequestor}`);
-          })
-          .catch(done);
-      });
+        describe('remove Overdue Fine Policy', function foo() {
+          helpers.removeOverdueFinePolicy(nightmare, overdueFinePolicyName);
+        });
 
-      const itembc = createInventory(nightmare, config, 'Request title');
+        describe('remove Lost Item Fee Policy', function foo() {
+          helpers.removeLostItemFeePolicy(nightmare, lostItemFeePolicyName);
+        });
 
-      it('should navigate to checkout', (done) => {
-        clickApp(nightmare, done, 'checkout', 1000);
-      });
-
-      it('should check out newly created item', (done) => {
-        checkout(nightmare, done, itembc, userbc);
-      });
-
-      it('should navigate to requests', (done) => {
-        clickApp(nightmare, done, 'requests', 1000);
-      });
-
-      it('should add a new "Hold" request', (done) => {
-        nightmare
-          .wait('#clickable-newrequest')
-          .click('#clickable-newrequest')
-          .insert('input[name="item.barcode"]', itembc)
-          .wait('#clickable-select-item')
-          .click('#clickable-select-item')
-          .wait('#section-item-info a[href^="/inventory/view/"]')
-          .wait('select[name="requestType"]')
-          .select('select[name="requestType"]', 'Hold')
-          .wait('input[name="requester.barcode"]')
-          .insert('input[name="requester.barcode"]', userbcRequestor)
-          .wait('#clickable-select-requester')
-          .click('#clickable-select-requester')
-          .wait('#section-requester-info a[href^="/users/view/"]')
-          .wait('select[name="fulfilmentPreference"]')
-          .select('select[name="fulfilmentPreference"]', 'Hold Shelf')
-          .wait('input[name="requestExpirationDate"]')
-          .insert('input[name="requestExpirationDate"]', nextMonth)
-
-          .evaluate((servicePointName) => {
-            const node = Array.from(
-              document.querySelectorAll('select[name="pickupServicePointId"] option')
-            ).find(e => e.text.startsWith(servicePointName));
-            if (node) {
-              return node.value;
-            }
-
-            throw new Error(`Could not find the ID for the servicePoint ${servicePointName} ${node}`);
-          }, servicePoint)
-          .then((servicePointId) => {
-            nightmare
-              .select('select[name="pickupServicePointId"]', servicePointId)
-              .wait('input[name="requestExpirationDate"]')
-              .insert('input[name="requestExpirationDate"]', nextMonth)
-              .wait('#clickable-save-request')
-              .click('#clickable-save-request')
-              .wait(() => !document.querySelector('#clickable-save-request'))
-              .wait(3333)
-              .then(done)
-              .catch(done);
-          })
-          .catch(done);
-      });
-
-      it('should find new request in requests list', (done) => {
-        nightmare
-          .wait('#input-request-search')
-          .insert('#input-request-search', itembc)
-          .wait('button[type="submit"]')
-          .click('button[type="submit"]')
-          .wait('#list-requests[data-total-count="1"]')
-          .then(done)
-          .catch(done);
-      });
-
-      it('should navigate to settings', (done) => {
-        clickSettings(nightmare, done);
-      });
-
-      it('should restore initial circulation rules', (done) => {
-        setCirculationRules(nightmare, initialRules)
-          .then(() => done())
-          .catch(done);
+        describe('remove Notice Policy', function foo() {
+          helpers.removeNoticePolicy(nightmare, noticePolicyName);
+        });
       });
     });
   });


### PR DESCRIPTION
This is a follow-up to #524, applying the same changes to additional
tests.

Use helpers to add/remove overdue fine policy, lost item fee policy, and
patron notice policy in the circulation rules that are created. Checkout
is now smart enough to check all the attributes of circulation policies
and if we just use dummy values, checkout will fail.

Refs [FOLIO-2440](https://issues.folio.org/browse/FOLIO-2440)