### PR TITLE
UIREQ-370 update ui-requests and its tests

### DIFF
--- a/install.json
+++ b/install.json
@@ -65,7 +65,7 @@
   "id" : "folio_plugin-find-user-1.9.1",
   "action" : "enable"
 }, {
-  "id" : "folio_requests-1.14.3",
+  "id" : "folio_requests-1.14.4",
   "action" : "enable"
 }, {
   "id" : "mod-codex-mux-2.7.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@folio/myprofile": "1.8.0",
     "@folio/plugin-find-instance": "1.6.0",
     "@folio/plugin-find-user": "1.9.1",
-    "@folio/requests": "1.14.3",
+    "@folio/requests": "1.14.4",
     "@folio/search": "1.10.0",
     "@folio/servicepoints": "1.4.2",
     "@folio/stripes": "2.12.1",

--- a/stripes-install.json
+++ b/stripes-install.json
@@ -36,7 +36,7 @@
     "action": "enable"
   },
   {
-    "id": "folio_requests-1.14.3",
+    "id": "folio_requests-1.14.4",
     "action": "enable"
   },
   {

--- a/test/ui-testing/new-request.js
+++ b/test/ui-testing/new-request.js
@@ -131,9 +131,9 @@ module.exports.test = function uiTest(uiTestCtx) {
               .select('select[name="pickupServicePointId"]', servicePointId)
               .wait('input[name="requestExpirationDate"]')
               .insert('input[name="requestExpirationDate"]', nextMonth)
-              .wait('#clickable-create-request')
-              .click('#clickable-create-request')
-              .wait(() => !document.querySelector('#clickable-create-request'))
+              .wait('#clickable-save-request')
+              .click('#clickable-save-request')
+              .wait(() => !document.querySelector('#clickable-save-request'))
               .wait(3333)
               .then(done)
               .catch(done);

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,10 +459,10 @@
   dependencies:
     sanitize-html "1.18.2"
 
-"@folio/requests@1.14.3":
-  version "1.14.3"
-  resolved "https://repository.folio.org/repository/npm-folio/@folio/requests/-/requests-1.14.3.tgz#bae504b28e3c620798bcfaddb79717af85df68d6"
-  integrity sha512-NnyT0OnfOxnUr14kPTzNF1rYAc/ErpD12Ja/qY7xq6wo9QL7XnS5hvk6h8qTIyX1T1DcXX1YQGUjwS2EFG7iiA==
+"@folio/requests@1.14.4":
+  version "1.14.4"
+  resolved "https://repository.folio.org/repository/npm-folio/@folio/requests/-/requests-1.14.4.tgz#253933c8ae792e1a4f465e25615131c76998bd67"
+  integrity sha512-ropsgcov1bctTIt91XeTdHkyPjf4zbPfmBaYcFp+t9Pz/E0GFA/K0r42Yhxarj8OZpEZhiXsWuK9sMbmLfxwsw==
   dependencies:
     "@folio/react-intl-safe-html" "^1.0.2"
     html-to-react "^1.3.3"
@@ -4419,9 +4419,9 @@ electron-download@^3.0.1:
     sumchecker "^1.2.0"
 
 electron-to-chromium@^1.3.349, electron-to-chromium@^1.3.47:
-  version "1.3.350"
-  resolved "https://repository.folio.org/repository/npm-ci-all/electron-to-chromium/-/electron-to-chromium-1.3.350.tgz#325654a3bf030b03b7b2bba967b44be3f13dc457"
-  integrity sha512-j2ge29AfeTXhlL1OyIIEuprvCEmxoW4tN52A/FiZ9PyXV427RxAQXpj2seCX9rnYExpOpuv4gbM3I9A7MM2hng==
+  version "1.3.351"
+  resolved "https://repository.folio.org/repository/npm-ci-all/electron-to-chromium/-/electron-to-chromium-1.3.351.tgz#78bcf8e9092013232b2fb72b9db423d96e92604c"
+  integrity sha512-L8zhV8k7Znp2q3wWXYDzCyfTBeGauEX0rX/FtgmnDgmvHRqwu9NVN614wOkXx9sDZmJZpNMBaEFMXTu/vbr+Kg==
 
 electron@^2.0.18:
   version "2.0.18"
@@ -7053,9 +7053,9 @@ jpeg-js@^0.2.0:
   integrity sha1-U+RI7J0mPmgyZkZ+lELSxaLvVII=
 
 jpeg-js@^0.3.4:
-  version "0.3.6"
-  resolved "https://repository.folio.org/repository/npm-ci-all/jpeg-js/-/jpeg-js-0.3.6.tgz#c40382aac9506e7d1f2d856eb02f6c7b2a98b37c"
-  integrity sha512-MUj2XlMB8kpe+8DJUGH/3UJm4XpI8XEgZQ+CiHDeyrGoKPdW/8FJv6ku+3UiYm5Fz3CWaL+iXmD8Q4Ap6aC1Jw==
+  version "0.3.7"
+  resolved "https://repository.folio.org/repository/npm-ci-all/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
+  integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
[`ui-requests` `v1.14.4`](https://github.com/folio-org/ui-requests/releases/v1.14.4) moves the save/cancel buttons to the form-footer and changes the HTML
`id` attribute.

Refs [UIREQ-370](https://issues.folio.org/browse/UIREQ-370)