### PR TITLE
STRIPES-664 unlock final-form resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,5 @@
     "moment": "^2.22.2"
   },
   "resolutions": {
-    "final-form": "4.18.5",
-    "react-final-form": "6.3.0"
   }
 }


### PR DESCRIPTION
We could have unlocked these resolutions months ago when
@aditya-matukumalli debugged this as a problem with `initialValues` and
merged folio-org/stripes-final-form/pull/19.

Refs [STRIPES-664](https://issues.folio.org/browse/STRIPES-664)