### PR TITLE
update stripes to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,13 +51,16 @@
     "@folio/requests": ">=1.4.1",
     "@folio/search": ">=1.3.0",
     "@folio/servicepoints": ">=1.1.0",
-    "@folio/stripes": "^2.10.0",
+    "@folio/stripes": "^3.0.0",
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
-    "react": "~16.8.6",
-    "react-dom": "~16.8.6",
+    "react": "~16.12.0",
+    "react-dom": "~16.12.0",
+    "react-intl": "^2.9.0",
     "react-redux": "^5.1.1",
+    "react-router": "^4.3.1",
+    "react-router-dom": "^4.3.1",
     "redux": "^3.7.2"
   },
   "devDependencies": {
@@ -66,6 +69,5 @@
     "eslint": "^6.2.1",
     "moment": "^2.22.2"
   },
-  "resolutions": {
-  }
+  "resolutions": {}
 }


### PR DESCRIPTION
Update `@folio/stripes` to `^3.0.0`. In addition, update React and
include `react-router` and `react-intl` as direct dependencies so that
other apps may include them as peers.