### PR TITLE
better checkout-list handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes-cli": "^1.13.0",
+    "@folio/stripes-cli": "^1.15.0",
     "eslint": "^6.2.1",
     "moment": "^2.22.2"
   },

--- a/test/ui-testing/many-items.js
+++ b/test/ui-testing/many-items.js
@@ -80,7 +80,9 @@ module.exports.test = (uiTestCtx) => {
       });
 
       it(`should checkout ${count} items`, (done) => {
-        helpers.checkoutList(nightmare, done, barcodes, userBarcode);
+        helpers.checkoutList(nightmare, barcodes, userBarcode)
+          .then(done)
+          .catch(done);
       });
     });
 


### PR DESCRIPTION
`stripes-testing` `v2.0.0`, available in `stripes-cli` `v1.15.0`,
correctly waits for all checkout actions to complete, rather than
immediately calling `done`, and returns the promise to the test to
allow `done` to be called there.