### PR TITLE
update MCL anchor handling (#69)

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -226,7 +226,7 @@ module.exports.test = (uiTestCtx) => {
           .wait('div.hasEntries')
           .evaluate((pn) => {
             const index = Array.from(
-              document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+              document.querySelectorAll('#ModuleContainer div.hasEntries a[class^=NavListItem]')
             )
               .findIndex(e => e.textContent === pn);
 
@@ -239,8 +239,8 @@ module.exports.test = (uiTestCtx) => {
           }, policyName)
           .then((entryIndex) => {
             nightmare
-              .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-              .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+              .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
+              .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
               .wait('#clickable-edit-item')
               .click('#clickable-edit-item')
               .wait('#input_allowed_renewals')
@@ -336,7 +336,7 @@ module.exports.test = (uiTestCtx) => {
           .wait('div.hasEntries')
           .evaluate((pn) => {
             const index = Array.from(
-              document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+              document.querySelectorAll('#ModuleContainer div.hasEntries a[class^=NavListItem]')
             )
               .findIndex(e => e.textContent === pn);
 
@@ -349,8 +349,8 @@ module.exports.test = (uiTestCtx) => {
           }, policyName)
           .then((entryIndex) => {
             nightmare
-              .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-              .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+              .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
+              .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
               .wait('#clickable-edit-item')
               .click('#clickable-edit-item')
               .wait('#input_loan_profile')
@@ -421,6 +421,7 @@ module.exports.test = (uiTestCtx) => {
             return !!(Array.from(document.querySelectorAll('#list-items-checked-in div[role="gridcell"]'))
               .find(e => e.textContent === `${bc}`));
           }, barcode)
+          .wait(1000)
           .then(done)
           .catch(done);
       });
@@ -468,13 +469,13 @@ module.exports.test = (uiTestCtx) => {
             .wait('div.hasEntries')
             .wait((sn) => {
               const index = Array.from(
-                document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+                document.querySelectorAll('#ModuleContainer div.hasEntries a[class^=NavListItem]')
               ).findIndex(e => e.textContent === sn);
               return index >= 0;
             }, scheduleName)
             .evaluate((sn) => {
               const index = Array.from(
-                document.querySelectorAll('#ModuleContainer div.hasEntries a div')
+                document.querySelectorAll('#ModuleContainer div.hasEntries a[class^=NavListItem]')
               ).findIndex(e => e.textContent === sn);
               if (index === -1) {
                 throw new Error(`Could not find the fixed due date schedule ${sn} to delete`);
@@ -484,8 +485,8 @@ module.exports.test = (uiTestCtx) => {
             }, scheduleName)
             .then((entryIndex) => {
               nightmare
-                .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
-                .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a`)
+                .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
+                .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
                 .wait('#generalInformation')
                 .wait('#fixedDueDateSchedule')
                 .wait('#clickable-edit-item')


### PR DESCRIPTION
Circulation-related settings used to have a selector like `a div` but it
appears that switched to `div a` ... somewhere, probably in
`<MultiColumnList>` in stripes-components. This update tries to make the
selectors a little bit more semantic/robust. I'm not sure if it actually
does that or if it just rearranges things, but in any case tests work
again, so, yay.

See also folio-org/stripes-testing/pull/69 for parallel changes in the
shared handlers.