### PR TITLE
STRIPES-678 resolve moment to v2.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,7 @@
     "eslint": "^6.2.1",
     "moment": "^2.22.2"
   },
-  "resolutions": {}
+  "resolutions": {
+    "moment": "~2.24.0"
+  }
 }


### PR DESCRIPTION
Pin `moment` at `~2.24.0` in light of multiple issues with `2.25.0` ([5489](https://github.com/moment/moment/issues/5489), [5472](https://github.com/moment/moment/issues/5472)).

Refs [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)