### PR TITLE
STRIPES-635 -678 provide moment v2.24 to peers

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes-cli": "^1.15.0",
     "eslint": "^6.2.1"
-  }
+  },
   "resolutions": {
     "moment": "~2.24.0"
   }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@folio/tags": ">=1.1.0",
     "@folio/tenant-settings": ">=2.5.1",
     "@folio/users": ">=2.17.0",
+    "moment": "~2.24.0",
     "react": "~16.12.0",
     "react-dom": "~16.12.0",
     "react-intl": "^2.9.0",
@@ -66,9 +67,8 @@
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes-cli": "^1.15.0",
-    "eslint": "^6.2.1",
-    "moment": "^2.22.2"
-  },
+    "eslint": "^6.2.1"
+  }
   "resolutions": {
     "moment": "~2.24.0"
   }


### PR DESCRIPTION
Provide a direct dep on `moment` `~2.24.0` so other repositories may
depend on it as a peer. Because we configure moment with the current
locale, it is important that all modules receive that same instance.

Refs [STRIPES-635](https://issues.folio.org/browse/STRIPES-635), [STRIPES-678](https://issues.folio.org/browse/STRIPES-678)