### PR TITLE
wait, not evaluate, for search results

### DIFF
--- a/test/ui-testing/codex-search.js
+++ b/test/ui-testing/codex-search.js
@@ -107,11 +107,8 @@ module.exports.test = (uiTestCtx) => {
         nightmare
           .wait('#clickable-reset-all')
           .click('#clickable-reset-all')
-          .evaluate(() => {
-            const results = document.querySelector('#list-search');
-            if (results) {
-              throw new Error('Found unexpected search results after reset');
-            }
+          .wait(() => {
+            return !document.querySelector('#list-search');
           })
           .then(done)
           .catch(done);


### PR DESCRIPTION
`evaluate()` only runs once but `wait()` runs until its condition
returns true. This last test started failing out of the blue a few days
ago for no clear reason -- no changes in ui-search -- but perhaps
something deeper down in the render hierarchy is causing it to go
through an extra cycle that we need to accommodate here.