### PR TITLE
CIRC-437 test updates

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -241,8 +241,8 @@ module.exports.test = (uiTestCtx) => {
             nightmare
               .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
               .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
-              .wait('#clickable-edit-item')
-              .click('#clickable-edit-item')
+              .wait('#dropdown-clickable-edit-item')
+              .click('#dropdown-clickable-edit-item')
               .wait('#input_allowed_renewals')
               .type('#input_allowed_renewals', 2)
               .wait('#select_renew_from')
@@ -351,8 +351,8 @@ module.exports.test = (uiTestCtx) => {
             nightmare
               .wait(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
               .click(`#ModuleContainer div.hasEntries div:nth-of-type(${entryIndex}) a[class^=NavListItem]`)
-              .wait('#clickable-edit-item')
-              .click('#clickable-edit-item')
+              .wait('#dropdown-clickable-edit-item')
+              .click('#dropdown-clickable-edit-item')
               .wait('#input_loan_profile')
               .type('#input_loan_profile', 'fi')
               .wait('#input_loansPolicy_fixedDueDateSchedule')


### PR DESCRIPTION
The `Edit` button for loan policies moved from a button into a dropdown
menu as part of UICIRC-437 /
/folio-org/stripes-smart-components/pull/806.

Refs [UICIRC-437](https://issues.folio.org/browse/UICIRC-437)