### PR TITLE
avoid buggy react-intl v4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update integration tests to accommodate MCL aria changes, STRIPES-596
 * Add ui-tenant-settings, the eventual replacement for ui-organization, UIORG-156
 * Update stripes-cli to get a newer stripes-testing with support for `clickApp` and `clickSettings`
+* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.  
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "moment": "~2.25.3",
     "react": "~16.12.0",
     "react-dom": "~16.12.0",
-    "react-intl": "^4.5.3",
+    "react-intl": "~4.6.10",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",


### PR DESCRIPTION
Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series,
https://github.com/formatjs/formatjs/issues/1744.  
