### PR TITLE
Ensure minimist is at least v1.2.3 in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^6.2.1"
   },
   "resolutions": {
+    "minimist": "^1.2.3",
     "moment": "~2.25.3"
   }
 }


### PR DESCRIPTION
because of prototype pollution security issue. See here for more info: https://app.snyk.io/vuln/SNYK-JS-MINIMIST-559764