### PR TITLE
use default request-policy

### DIFF
--- a/test/ui-testing/loan-renewal.js
+++ b/test/ui-testing/loan-renewal.js
@@ -28,7 +28,8 @@ module.exports.test = (uiTestCtx) => {
     const policyName = `test-policy-${Math.floor(Math.random() * 10000)}`;
     const scheduleName = `test-schedule-${Math.floor(Math.random() * 10000)}`;
     const noticePolicyName = `test-notice-policy-${Math.floor(Math.random() * 10000)}`;
-    const requestPolicyName = `test-request-policy-${Math.floor(Math.random() * 10000)}`;
+    // const requestPolicyName = `test-request-policy-${Math.floor(Math.random() * 10000)}`;
+    const requestPolicyName = 'allow-all';
     const overdueFinePolicyName = `test-overdue-fine-policy-${Math.floor(Math.random() * 10000)}`;
     const lostItemFeePolicyName = `test-lost-item-fee-policy-${Math.floor(Math.random() * 10000)}`;
 
@@ -83,9 +84,9 @@ module.exports.test = (uiTestCtx) => {
         helpers.addLoanPolicy(nightmare, policyName, loanPeriod, renewalLimit);
       });
 
-      describe('addRequestPolicy', function foo() {
-        helpers.addRequestPolicy(nightmare, requestPolicyName);
-      });
+      // describe('addRequestPolicy', function foo() {
+      //   helpers.addRequestPolicy(nightmare, requestPolicyName);
+      // });
 
       describe('it should configure circulation rules', function foo() {
         it('set new rules circulation rules', (done) => {
@@ -454,9 +455,9 @@ module.exports.test = (uiTestCtx) => {
         helpers.removeLoanPolicy(nightmare, policyName);
       });
 
-      describe('remove request policy', () => {
-        helpers.removeRequestPolicy(nightmare, requestPolicyName);
-      });
+      // describe('remove request policy', () => {
+      //   helpers.removeRequestPolicy(nightmare, requestPolicyName);
+      // });
 
       describe('Delete fixed due date schedule', () => {
         it('should delete the fixed due date schedule', (done) => {


### PR DESCRIPTION
The request policy form was [recently refactored](https://github.com/folio-org/ui-circulation/pull/535) to use final-form, and Nightmare is super unhappy about that. It isn't entirely clear what the issue is. We [discussed this on Slack](https://folio-project.slack.com/archives/C210UCHQ9/p1593176052423400) but didn't reach any firm conclusions.

The approach here is to simply avoid interacting with the request policy
form since we don't actually do anything request-policy-related in the
tests.