### PR TITLE
Add create-inventory-records plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Update integration tests to accommodate MCL aria changes, STRIPES-596
 * Add ui-tenant-settings, the eventual replacement for ui-organization, UIORG-156
 * Update stripes-cli to get a newer stripes-testing with support for `clickApp` and `clickSettings`
-* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.  
+* Move `react-intl` from `^4.5` to `~4.6` to avoid the broken `4.7` series, https://github.com/formatjs/formatjs/issues/1744.
+* Add `ui-plugin-create-inventory-records` to the list of dependecies and modules.
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@folio/developer": ">=1.5.0",
     "@folio/inventory": ">=1.4.0",
     "@folio/myprofile": ">=1.1.0",
+    "@folio/plugin-create-inventory-records": ">=1.0.0",
     "@folio/plugin-find-instance": ">=1.1.0",
     "@folio/plugin-find-user": ">=1.3.0",
     "@folio/requests": ">=1.4.1",

--- a/stripes.config.js
+++ b/stripes.config.js
@@ -13,6 +13,7 @@ module.exports = {
     '@folio/developer' : {},
     '@folio/inventory' : {},
     '@folio/myprofile' : {},
+    '@folio/plugin-create-inventory-records' : {},
     '@folio/plugin-find-instance' : {},
     '@folio/plugin-find-user' : {},
     '@folio/requests' : {},


### PR DESCRIPTION
This PR includes https://github.com/folio-org/ui-plugin-create-inventory-records to the list of dependencies. 