### PR TITLE
FOLIO-2727 temporarily disable flakey tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",
     "test": "echo 'No unit tests implemented'",
     "test-int": "stripes test nightmare stripes.config.js",
-    "test-regression": "stripes test nightmare stripes.config.js --run WD/checkout/users/inventory/requests/circulation/tenant-settings",
+    "test-regression": "stripes test nightmare stripes.config.js --run WD/checkout/users/inventory/requests/circulation",
     "lint": "eslint test/ui-testing"
   },
   "dependencies": {


### PR DESCRIPTION
I love this test. It is my favorite test in all off my nightmare tests.
I love this test the most because it always succeeds when I run it in
isolation and always fails when I run it as part of the suite. This
makes it extra special and extra deserving of my love. NightmareJS and
consistent test results walk hand in hand together like love, marriage,
and ritual infanticide. A test is a test of course, I Jest, and no one
can talk to a test unless, that is, oh hell, unless you spell, your test
like R-T-L. What if the BigTest is not big enough? _He cries_. Writing
more tests in NightmareJS will liquify the nerves of the sentient beings
*it begins*. It is a journey. It is a journey up a river of c͒ͪo͛ͫrruption.
*_He comes_*. It is a journey across the water in search of a m̡adman,
in se̶arch of darkne̸ss, into darkness, into the heart of darkness, it is
darknes̸s̸. My NightmareJS is a waking dream. Goodnight darkness,
goodnight test, goodnight ̕un̨ho͞ly radiańcé destro҉yer of enli̍̈́̂̈́ghtenment.
WE ARE LOST. Goodnight enzymes, goodn̷ight proteinŚ͖̩͇̗̪̏̈́, goodnight little
bowl of m̷̙̲̝͖ͭ̏ͥͮ͟uͮ͏̮̪̝͍̲̖͊̒ͪͩͬ̚̚͜s̴̟̟͙̞̑ͩ͌͝h̨̥̫͎̭ͯ̿̔̀ͅ. HUSH. The end is nigh.

Refs [FOLIO-2727](https://issues.folio.org/browse/FOLIO-2727), [FOLIO-2723](https://issues.folio.org/browse/FOLIO-2723)