### PR TITLE
FOLIO-2781 Re-add missing extra modules

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -2,5 +2,9 @@
   {
     "id": "mod-codex-inventory",
      "action": "enable"
+  },
+  {
+    "id": "mod-graphql",
+    "action": "enable"
   }
 ]


### PR DESCRIPTION
Compared the old configuration at folio-ansible/group_vars/snapshot-core "add_modules"
The mod-graphql is the only one missing.