### PR TITLE
STRIPES-721 upgrade to react-redux 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Update `react-intl` to `^5.7.0`, STRIPES-694
 * Update `moment` to `~2.29`. STRIPES-702.
 * Update `react` to `~17.0`. STRIPES-722.
+* Update `redux` to `^4.0`, `react-redux` to `^7.2`. Refs STRIPES-721.
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "react": "~17.0.1",
     "react-dom": "~17.0.1",
     "react-intl": "^5.7.0",
-    "react-redux": "^5.1.1",
+    "react-redux": "^7.2.2",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "redux": "^3.7.2"
+    "redux": "^4.0.5"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",


### PR DESCRIPTION
Increment `redux` to `v4`, `react-redux` to `v7`.

Refs [STRIPES-721](https://issues.folio.org/browse/STRIPES-721)