### PR TITLE
STCOR-504 force redux-form v8 on apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "resolutions": {
     "minimist": "^1.2.3",
-    "moment": "~2.29.0"
+    "moment": "~2.29.0",
+    "redux-form": "^8.0.0"
   }
 }


### PR DESCRIPTION
redux-form probably needs to be a peer-dep so that things like
stripes-components and ui-apps all have the same expectations about the
underlying redux store.

Refs [STCOR-504](https://issues.folio.org/browse/STCOR-504)