### PR TITLE
STRIPES-733 update stripes-cli to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Update `moment` to `~2.29`. STRIPES-702.
 * Update `redux` to `^4.0`, `react-redux` to `^7.2`. Refs STRIPES-721.
 * Provide `react-titled`. Refs STCOR-503.
+* Update `@folio/stripes-cli` to `v2`. Refs STRIPES-733.
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -68,10 +68,11 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "eslint": "^6.2.1"
   },
   "resolutions": {
+    "@folio/stripes-cli": "^2.0.0",
     "minimist": "^1.2.3",
     "moment": "~2.29.0",
     "redux-form": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -28,11 +28,10 @@
     "all": false
   },
   "scripts": {
-    "build": "export NODE_OPTIONS=\"--max-old-space-size=4096 $NODE_OPTIONS\"; stripes build stripes.config.js",
-    "stripes": "stripes",
-    "start": "stripes serve stripes.config.js",
-    "build-module-descriptors": "stripes mod descriptor stripes.config.js --output ./ModuleDescriptors",
-    "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; stripes serve $f",
+    "build": "export NODE_OPTIONS=\"--max-old-space-size=4096 $NODE_OPTIONS\"; yarn stripes build stripes.config.js",
+    "start": "yarn stripes serve stripes.config.js",
+    "build-module-descriptors": "yarn stripes mod descriptor stripes.config.js --output ./ModuleDescriptors",
+    "local": "f=stripes.config.js; test -f $f.local && f=$f.local; echo Using config $f; yarn stripes serve $f",
     "test": "echo 'No unit tests implemented'",
     "test-int": "echo 'No end-to-end tests implemented'",
     "test-regression": "echo 'No end-to-end tests implemented'",


### PR DESCRIPTION
Pin `@folio/stripes-cli` to `v2` via resolutions so we don't get
multiple copies of `@folio/stripes-core` and `@folio/stripes-components`
via `v1`. We can remove the resolutions entry as soon as all the tickets
linked to [STCLI-169](https://issues.folio.org/browse/STCLI-169) are closed.

Refs [STRIPES-733](https://issues.folio.org/browse/STRIPES-733)