### PR TITLE
STRIPES-735 provide react-query, swr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update `redux` to `^4.0`, `react-redux` to `^7.2`. Refs STRIPES-721.
 * Provide `react-titled`. Refs STCOR-503.
 * Update `@folio/stripes-cli` to `v2`. Refs STRIPES-733.
+* Provide `react-query` and `swr`. Refs STRIPES-735.
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -59,11 +59,13 @@
     "react": "~16.13.0",
     "react-dom": "~16.13.0",
     "react-intl": "^5.7.0",
+    "react-query": "^3.13.0",
     "react-redux": "^7.2.2",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "swr": "^0.4.2"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.0.0",


### PR DESCRIPTION
`stripes-core` wraps apps in contexts for `react-query` and `swr`, so we
need to provide those modules at the platform level so all modules can
depend on the same version as peers.

Refs [STRIPES-735](https://issues.folio.org/browse/STRIPES-735)