### PR TITLE
MODLOGSAML-130: Pac4j 5.2.1 fixing unsecure token (CVE-2021-44878)

### DIFF
--- a/install-extras.json
+++ b/install-extras.json
@@ -112,7 +112,7 @@
     "action": "enable"
   },
   {
-    "id": "mod-login-saml-2.3.2",
+    "id": "mod-login-saml-2.4.0",
     "action": "enable"
   },
   {


### PR DESCRIPTION
mod-login-saml 2.4.0 with
https://issues.folio.org/browse/MODLOGSAML-130
https://nvd.nist.gov/vuln/detail/CVE-2021-44878