### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Provide `react-titled`. Refs STCOR-503.
 * Update `@folio/stripes-cli` to `v2`. Refs STRIPES-733.
 * Provide `react-query` and `swr`. Refs STRIPES-735.
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
 
 ## [1.3.0](https://github.com/folio-org/platform-core/tree/v1.3.0-SNAPSHOT) (2019-01-23)
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": "~17.0.2",
     "react-intl": "^5.7.0",
     "react-query": "^3.13.0",
-    "react-redux": "^7.2.2",
+    "react-redux": "^8.0.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-titled": "^1.0.1",


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STRIPES-834.
- Upgrade will be happening across all of Stripes framework and modules that reference react-redux.
- v7 to v8 is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.